### PR TITLE
Functionality to communicate with CCS811 sensor

### DIFF
--- a/PiDashboardBackend/PiDashboardBackend.vcxproj
+++ b/PiDashboardBackend/PiDashboardBackend.vcxproj
@@ -36,6 +36,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\drivers\bme280_barometer.cpp" />
+    <ClCompile Include="src\drivers\ccs811_co2.cpp" />
     <ClCompile Include="src\main.cpp" />
     <ClCompile Include="src\manager\db_manager_table_management.cpp" />
     <ClCompile Include="src\manager\db_manager_sensors.cpp" />
@@ -46,6 +47,10 @@
     <ClInclude Include="src\drivers\bme280_barometer.h" />
     <ClInclude Include="src\drivers\bme280_barometer_constants.h" />
     <ClInclude Include="src\drivers\bme280_barometer_definitions.h" />
+    <ClInclude Include="src\drivers\ccs811_co2.h" />
+    <ClInclude Include="src\drivers\ccs811_co2_constants.h" />
+    <ClInclude Include="src\drivers\ccs811_co2_definitions.h" />
+    <ClInclude Include="src\drivers\sensor_base.h" />
     <ClInclude Include="src\dto\sensor_dto.h" />
     <ClInclude Include="src\dto\extremas_dto.h" />
     <ClInclude Include="src\dto\query_object.h" />
@@ -104,7 +109,7 @@
       </AdditionalLibraryDirectories>
       <AdditionalDependencies>
       </AdditionalDependencies>
-      <LibraryDependencies>mysqlclient</LibraryDependencies>
+      <LibraryDependencies>mysqlclient;wiringPi;pthread</LibraryDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
@@ -113,7 +118,7 @@
       </AdditionalLibraryDirectories>
       <AdditionalDependencies>
       </AdditionalDependencies>
-      <LibraryDependencies>mysqlclient</LibraryDependencies>
+      <LibraryDependencies>mysqlclient;wiringPi;pthread</LibraryDependencies>
     </Link>
     <ClCompile>
       <AdditionalIncludeDirectories>/usr/include/mysql/</AdditionalIncludeDirectories>

--- a/PiDashboardBackend/PiDashboardBackend.vcxproj.filters
+++ b/PiDashboardBackend/PiDashboardBackend.vcxproj.filters
@@ -31,6 +31,9 @@
     <ClCompile Include="src\manager\i2c_manager.cpp">
       <Filter>manager</Filter>
     </ClCompile>
+    <ClCompile Include="src\drivers\ccs811_co2.cpp">
+      <Filter>drivers</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\manager\db_manager.h">
@@ -59,6 +62,18 @@
     </ClInclude>
     <ClInclude Include="src\manager\i2c_manager.h">
       <Filter>manager</Filter>
+    </ClInclude>
+    <ClInclude Include="src\drivers\ccs811_co2.h">
+      <Filter>drivers</Filter>
+    </ClInclude>
+    <ClInclude Include="src\drivers\ccs811_co2_constants.h">
+      <Filter>drivers</Filter>
+    </ClInclude>
+    <ClInclude Include="src\drivers\sensor_base.h">
+      <Filter>drivers</Filter>
+    </ClInclude>
+    <ClInclude Include="src\drivers\ccs811_co2_definitions.h">
+      <Filter>drivers</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/PiDashboardBackend/src/drivers/bme280_barometer.cpp
+++ b/PiDashboardBackend/src/drivers/bme280_barometer.cpp
@@ -1,31 +1,31 @@
 #include "bme280_barometer.h"
 
-int8_t driver::sensors::bme280::barometer::init(uint8_t device_address,
-	std::function<int8_t(int, uint8_t, std::unique_ptr<uint8_t[]>&, uint16_t)> read_function,
-	std::function<int8_t(int, uint8_t, const std::unique_ptr<uint8_t[]>&, uint16_t)> write_function,
+int8_t driver::sensors::bme280::barometer::init(uint8_t device_reg,
+	std::function<int8_t(int, uint8_t, uint8_t*, uint16_t)> read_function,
+	std::function<int8_t(int, uint8_t, const uint8_t*, uint16_t)> write_function,
 	std::function<int8_t(const std::string, uint8_t, int&)> open_device_function,
 	std::function<int8_t(int&)> close_device_function)
 {
+	m_dev_id = device_reg;
 	m_device = bme280_device();
-	m_device.dev_id = device_address;
 	m_read_function = read_function;
 	m_write_function = write_function;
 	m_open_device_function = open_device_function;
 	m_close_device_function = close_device_function;
 
-	if (m_open_device_function(manager::i2c_manager::DEFAULT_PI_I2C_ADDRESS, device_address, m_file_handle) != OK)
+	if (m_open_device_function(manager::i2c_manager::DEFAULT_PI_I2C_PATH, device_reg, m_file_handle) != OK)
 	{
-		std::cerr << "BME280 [init] Error: Could not establish connection with device via WiringPi" << std::endl;
+		std::cerr << "BME280 [init] Error: Could not establish connection with device." << std::endl;
 		return DEVICE_NOT_FOUND;
 	}
 
 	uint8_t try_count = 5;
-	std::unique_ptr<uint8_t[]> chip_id(new uint8_t[1]);
+	uint8_t chip_id;
 	while (try_count)
 	{
-		if (m_read_function(m_file_handle, CHIP_ID_ADDR, chip_id, 1) == OK)
+		if (m_read_function(m_file_handle, CHIP_ID_REG, &chip_id, 1) == OK)
 		{
-			m_device.chip_id = *chip_id.get();
+			m_id = chip_id;
 			if (soft_reset() == OK)
 			{
 				get_calibration_data(m_device.calibration_data);
@@ -38,7 +38,7 @@ int8_t driver::sensors::bme280::barometer::init(uint8_t device_address,
 
 	if (!try_count)
 	{
-		std::cerr << "BME280 [init] Error: Could not find device" << std::endl;
+		std::cerr << "BME280 [init] Error: Could not find read chip id from the device." << std::endl;
 		return DEVICE_NOT_FOUND;
 	}
 
@@ -47,16 +47,15 @@ int8_t driver::sensors::bme280::barometer::init(uint8_t device_address,
 
 int8_t driver::sensors::bme280::barometer::close()
 {
-	m_close_device_function(m_file_handle);
-	return int8_t();
+	return m_close_device_function(m_file_handle);
 }
 
 int8_t driver::sensors::bme280::barometer::set_pressure_and_temperature_oversampling(uint8_t desired_settings, struct settings_data settings)
 {
-	uint8_t reg_addr = MEASUREMENT_OVERSAMPLING_ADDR;
-	std::unique_ptr<uint8_t[]> reg_data(new uint8_t[1]);
+	uint8_t reg_REG = MEASUREMENT_OVERSAMPLING_REG;
+	uint8_t reg_data[1];
 
-	if (m_read_function(m_file_handle, reg_addr, reg_data, 1) != OK)
+	if (m_read_function(m_file_handle, reg_REG, reg_data, 1) != OK)
 	{
 		std::cerr << "BME280 [set_pressure_and_temperature_oversampling] Error: Could not read pressure and temperature oversampling setting from device" << std::endl;
 		return COMMUNICATION_FAIL;
@@ -64,15 +63,15 @@ int8_t driver::sensors::bme280::barometer::set_pressure_and_temperature_oversamp
 
 	if (desired_settings & PRESSURE_SETTING_SELECTION)
 	{
-		reg_data.get()[0] = (uint8_t)((reg_data.get()[0] & ~((PRESSURE_MASK))) | ((settings.pressure_oversampling << (PRESSURE_POS)) & (PRESSURE_MASK)));
+		reg_data[0] = (uint8_t)((reg_data[0] & ~((PRESSURE_MASK))) | ((settings.pressure_oversampling << (PRESSURE_POS)) & (PRESSURE_MASK)));
 	}
 	if (desired_settings & TEMPERATURE_SETTING_SELECTION)
 	{
-		reg_data.get()[0] = (uint8_t)((reg_data.get()[0] & ~((TEMPERATURE_MASK))) | ((settings.temperature_oversampling << (TEMPERATURE_POS)) & (TEMPERATURE_MASK)));
+		reg_data[0] = (uint8_t)((reg_data[0] & ~((TEMPERATURE_MASK))) | ((settings.temperature_oversampling << (TEMPERATURE_POS)) & (TEMPERATURE_MASK)));
 	}
 
 	/* Write the oversampling settings in the register */
-	if (m_write_function(m_file_handle, reg_addr, std::move(reg_data), 1) != OK)
+	if (m_write_function(m_file_handle, reg_REG, std::move(reg_data), 1) != OK)
 	{
 		std::cerr << "BME280 [set_pressure_and_temperature_oversampling] Error: Could not write pressure and temperature oversampling settings to device" << std::endl;
 		return COMMUNICATION_FAIL;
@@ -86,23 +85,23 @@ int8_t driver::sensors::bme280::barometer::set_humidity_oversampling(struct sett
 	/* Humidity related changes will be only effective after a
 	 * write operation to ctrl_meas register
 	 */
-	uint8_t reg_addr = HUMIDITY_OVERSAMPLING_ADDR;
-	std::unique_ptr<uint8_t[]> ctrl_hum(new uint8_t[1]{ (uint8_t)(settings.humidity_oversampling & HUMIDITY_MASK) });
-	if (m_write_function(m_file_handle, reg_addr, ctrl_hum, 1) != OK)
+	uint8_t reg_REG = HUMIDITY_OVERSAMPLING_REG;
+	uint8_t ctrl_hum[1] = { (uint8_t)(settings.humidity_oversampling & HUMIDITY_MASK) };
+	if (m_write_function(m_file_handle, reg_REG, ctrl_hum, 1) != OK)
 	{
 		std::cerr << "BME280 [set_humidity_oversampling] Error: Could not write humidity setting to device" << std::endl;
 		return COMMUNICATION_FAIL;
 	}
 
-	reg_addr = MEASUREMENT_OVERSAMPLING_ADDR;
-	std::unique_ptr<uint8_t[]> ctrl_meas(new uint8_t[1]);
-	if (m_read_function(m_file_handle, reg_addr, ctrl_meas, 1) != OK)
+	reg_REG = MEASUREMENT_OVERSAMPLING_REG;
+	uint8_t ctrl_meas[1];
+	if (m_read_function(m_file_handle, reg_REG, ctrl_meas, 1) != OK)
 	{
 		std::cerr << "BME280 [set_humidity_oversampling] Error: Could not read settings from device" << std::endl;
 		return COMMUNICATION_FAIL;
 	}
 
-	if (m_write_function(m_file_handle, reg_addr, ctrl_meas, 1) != OK)
+	if (m_write_function(m_file_handle, reg_REG, ctrl_meas, 1) != OK)
 	{
 		std::cerr << "BME280 [set_humidity_oversampling] Error: Could not write settings to device" << std::endl;
 		return COMMUNICATION_FAIL;
@@ -113,10 +112,10 @@ int8_t driver::sensors::bme280::barometer::set_humidity_oversampling(struct sett
 
 int8_t driver::sensors::bme280::barometer::set_filter_and_standby_settings(uint8_t desired_settings, settings_data settings)
 {
-	uint8_t reg_addr = CONFIG_ADDR;
-	std::unique_ptr<uint8_t[]> reg_data(new uint8_t[1]);
+	uint8_t reg_REG = CONFIG_REG;
+	uint8_t reg_data[1];
 
-	if (m_read_function(m_file_handle, reg_addr, reg_data, 1) != OK)
+	if (m_read_function(m_file_handle, reg_REG, reg_data, 1) != OK)
 	{
 		std::cerr << "BME280 [set_filter] Error: Could not read filter and standby settings from device" << std::endl;
 		return COMMUNICATION_FAIL;
@@ -124,15 +123,15 @@ int8_t driver::sensors::bme280::barometer::set_filter_and_standby_settings(uint8
 
 	if (desired_settings & FILTER_SETTING_SELECTION)
 	{
-		reg_data.get()[0] = (uint8_t)((reg_data.get()[0] & ~((FILTER_MASK))) | ((settings.filter << (FILTER_POS)) & (FILTER_MASK)));
+		reg_data[0] = (uint8_t)((reg_data[0] & ~((FILTER_MASK))) | ((settings.filter << (FILTER_POS)) & (FILTER_MASK)));
 	}
 	if (desired_settings & STANDBY_SETTING_SELECTION)
 	{
-		reg_data.get()[0] = (uint8_t)((reg_data.get()[0] & ~((STANDBY_MASK))) | ((settings.standby_time << (STANDBY_POS)) & (STANDBY_MASK)));
+		reg_data[0] = (uint8_t)((reg_data[0] & ~((STANDBY_MASK))) | ((settings.standby_time << (STANDBY_POS)) & (STANDBY_MASK)));
 
 	}
 
-	if (m_write_function(m_file_handle, reg_addr, reg_data, 1) != OK)
+	if (m_write_function(m_file_handle, reg_REG, reg_data, 1) != OK)
 	{
 		std::cerr << "BME280 [set_filter] Error: Could not write filter and standby settings to device" << std::endl;
 		return COMMUNICATION_FAIL;
@@ -152,16 +151,16 @@ int8_t driver::sensors::bme280::barometer::set_sensor_mode(enum bme280_mode mode
 
 	if (mode != last_mode)
 	{
-		std::unique_ptr<uint8_t[]> reg_data(new uint8_t[1]);
+		uint8_t reg_data[1];
 
-		if (m_read_function(m_file_handle, MODE_ADDR, reg_data, 1) != OK)
+		if (m_read_function(m_file_handle, MODE_REG, reg_data, 1) != OK)
 		{
 			std::cerr << "BME280 [set_sensor_mode] Error: Could not read settings from device" << std::endl;
 			return COMMUNICATION_FAIL;
 		}
 
-		reg_data.get()[0] = (uint8_t)((reg_data.get()[0] & ~((SENSOR_MODE_MASK))) | ((uint8_t)mode & (SENSOR_MODE_MASK)));
-		if (m_write_function(m_file_handle, MODE_ADDR, reg_data, 1) != OK)
+		reg_data[0] = (uint8_t)((reg_data[0] & ~((SENSOR_MODE_MASK))) | ((uint8_t)mode & (SENSOR_MODE_MASK)));
+		if (m_write_function(m_file_handle, MODE_REG, reg_data, 1) != OK)
 		{
 			std::cerr << "BME280 [set_sensor_mode] Error: Could not write new sensor mode" << std::endl;
 			return COMMUNICATION_FAIL;
@@ -173,19 +172,18 @@ int8_t driver::sensors::bme280::barometer::set_sensor_mode(enum bme280_mode mode
 
 int8_t driver::sensors::bme280::barometer::get_sensor_mode(enum bme280_mode& mode)
 {
-	std::unique_ptr<uint8_t[]> result(new uint8_t[1]{ 0 });
-
+	uint8_t result[1] = { 0 };
 	/* Read the power mode register */
-	if (m_read_function(m_file_handle, MODE_ADDR, result, 1) != OK)
+	if (m_read_function(m_file_handle, MODE_REG, result, 1) != OK)
 	{
 		std::cerr << "BME280 [get_sensor_mode] Error: Could not read device mode" << std::endl;
 		return COMMUNICATION_FAIL;
 	}
 
-	result.get()[0] = (result.get()[0] & (((SENSOR_MODE_MASK))));
-	if (result.get()[0] == 0) mode = bme280_mode::SLEEP;
-	else if (result.get()[0] == 1 || result.get()[0] == 2) mode = bme280_mode::FORCED;
-	else if (result.get()[0] == 3) mode = bme280_mode::NORMAL;
+	result[0] = (result[0] & (((SENSOR_MODE_MASK))));
+	if (result[0] == 0) mode = bme280_mode::SLEEP;
+	else if (result[0] == 1 || result[0] == 2) mode = bme280_mode::FORCED;
+	else if (result[0] == 3) mode = bme280_mode::NORMAL;
 
 	return OK;
 }
@@ -199,7 +197,7 @@ int8_t driver::sensors::bme280::barometer::set_settings(enum bme280_oversampling
 	m_device.settings.standby_time = (uint8_t)standby;
 
 	uint8_t settings_sel = PRESSURE_SETTING_SELECTION | TEMPERATURE_SETTING_SELECTION | HUMIDITY_SETTING_SELECTION | FILTER_SETTING_SELECTION | STANDBY_SETTING_SELECTION;
-	std::unique_ptr<struct settings_data> settings = std::make_unique<struct settings_data>();
+	std::shared_ptr<struct settings_data> settings = std::make_shared<struct settings_data>();
 	enum bme280_mode sensor_mode;
 
 	if (get_sensor_mode(sensor_mode) != OK)
@@ -258,9 +256,9 @@ int8_t driver::sensors::bme280::barometer::set_settings(enum bme280_oversampling
 	return OK;
 }
 
-int8_t driver::sensors::bme280::barometer::get_settings(std::unique_ptr<struct settings_data>& settings)
+int8_t driver::sensors::bme280::barometer::get_settings(std::shared_ptr<struct settings_data>& settings)
 {
-	std::unique_ptr<uint8_t[]> reg_data(new uint8_t[4]);
+	uint8_t reg_data[4];
 
 	if (null_check(settings.get()) != OK)
 	{
@@ -268,7 +266,7 @@ int8_t driver::sensors::bme280::barometer::get_settings(std::unique_ptr<struct s
 		return NULL_PTR;
 	}
 
-	if (m_read_function(m_file_handle, HUMIDITY_OVERSAMPLING_ADDR, reg_data, 4) != OK)
+	if (m_read_function(m_file_handle, HUMIDITY_OVERSAMPLING_REG, reg_data, 4) != OK)
 	{
 		std::cerr << "BME280 [get_settings] Error: Could not read settings data from device" << std::endl;
 		return COMMUNICATION_FAIL;
@@ -281,23 +279,23 @@ int8_t driver::sensors::bme280::barometer::get_settings(std::unique_ptr<struct s
 
 int8_t driver::sensors::bme280::barometer::soft_reset()
 {
-	std::unique_ptr<uint8_t[]> data(new uint8_t[1]{ SOFT_RESET_VALUE });
-	if (m_write_function(m_file_handle, SOFT_RESET_ADDR, data, 1) != OK)
+	uint8_t data[1] = { SOFT_RESET_VALUE };
+	if (m_write_function(m_file_handle, SOFT_RESET_REG, data, 1) != OK)
 	{
 		std::cerr << "BME280 [soft_reset] Error: Could not write soft reset command to device" << std::endl;
 		return COMMUNICATION_FAIL;
 	}
 
-	std::unique_ptr<uint8_t[]> status_reg(new uint8_t[1]{ 0 });
+	uint8_t status_reg[1] = { 0 };
 	uint8_t try_run = 5;
 	int8_t result;
 	do
 	{
 		usleep(2000);
-		result = m_read_function(m_file_handle, STATUS_ADDR, status_reg, 1);
-	} while ((result == OK) && (try_run--) && (status_reg.get()[0] & STATUS_DURING_UPDATE));
+		result = m_read_function(m_file_handle, STATUS_REG, status_reg, 1);
+	} while ((result == OK) && (try_run--) && (status_reg[0] & STATUS_DURING_UPDATE));
 
-	if (status_reg.get()[0] & STATUS_DURING_UPDATE)
+	if (status_reg[0] & STATUS_DURING_UPDATE)
 	{
 		std::cerr << "BME280 [soft_reset] Error: NVM copy failed" << std::endl;
 		return NVM_COPY_FAILED;
@@ -322,9 +320,9 @@ int8_t driver::sensors::bme280::barometer::get_temperature_data(double& temperat
 
 	sleep_until_ready();
 
-	std::unique_ptr<uint8_t[]> reg_data(new uint8_t[ALL_DATA_LENGTH]{ 0 });
-	std::unique_ptr<struct raw_data> raw = std::make_unique<struct raw_data>();
-	if (m_read_function(m_file_handle, DATA_ADDR, reg_data, ALL_DATA_LENGTH) != OK)
+	uint8_t reg_data[ALL_DATA_LENGTH] = { 0 };
+	std::shared_ptr<struct raw_data> raw = std::make_shared<struct raw_data>();
+	if (m_read_function(m_file_handle, DATA_REG, reg_data, ALL_DATA_LENGTH) != OK)
 	{
 		std::cerr << "BME280 [get_temperature_data] Error: Could not read raw data" << std::endl;
 		return COMMUNICATION_FAIL;
@@ -349,9 +347,9 @@ int8_t driver::sensors::bme280::barometer::get_pressure_data(double& pressure)
 
 	sleep_until_ready();
 
-	std::unique_ptr<uint8_t[]> reg_data(new uint8_t[ALL_DATA_LENGTH]{ 0 });
-	std::unique_ptr<struct raw_data> raw = std::make_unique<struct raw_data>();
-	if (m_read_function(m_file_handle, DATA_ADDR, reg_data, ALL_DATA_LENGTH) != OK)
+	uint8_t reg_data[ALL_DATA_LENGTH] = { 0 };
+	std::shared_ptr<struct raw_data> raw = std::make_shared<struct raw_data>();
+	if (m_read_function(m_file_handle, DATA_REG, reg_data, ALL_DATA_LENGTH) != OK)
 	{
 		std::cerr << "BME280 [get_pressure_data] Error: Could not read raw data" << std::endl;
 		return COMMUNICATION_FAIL;
@@ -376,9 +374,9 @@ int8_t driver::sensors::bme280::barometer::get_humidity_data(double& humidity)
 
 	sleep_until_ready();
 
-	std::unique_ptr<uint8_t[]> reg_data(new uint8_t[ALL_DATA_LENGTH]{ 0 });
-	std::unique_ptr<struct raw_data> raw = std::make_unique<struct raw_data>();
-	if (m_read_function(m_file_handle, DATA_ADDR, reg_data, ALL_DATA_LENGTH) != OK)
+	uint8_t reg_data[ALL_DATA_LENGTH] = { 0 };
+	std::shared_ptr<struct raw_data> raw = std::make_shared<struct raw_data>();
+	if (m_read_function(m_file_handle, DATA_REG, reg_data, ALL_DATA_LENGTH) != OK)
 	{
 		std::cerr << "BME280 [get_humidity_data] Error: Could not read raw data" << std::endl;
 		return COMMUNICATION_FAIL;
@@ -403,9 +401,9 @@ int8_t driver::sensors::bme280::barometer::get_all_data(double& temperature, dou
 
 	sleep_until_ready();
 
-	std::unique_ptr<uint8_t[]> reg_data(new uint8_t[ALL_DATA_LENGTH]{ 0 });
-	std::unique_ptr<struct raw_data> raw = std::make_unique<struct raw_data>();
-	if (m_read_function(m_file_handle, DATA_ADDR, reg_data, ALL_DATA_LENGTH) != OK)
+	uint8_t reg_data[ALL_DATA_LENGTH] = { 0 };
+	std::shared_ptr<struct raw_data> raw = std::make_shared<struct raw_data>();
+	if (m_read_function(m_file_handle, DATA_REG, reg_data, ALL_DATA_LENGTH) != OK)
 	{
 		std::cerr << "BME280 [get_all_data] Error: Could not read raw data" << std::endl;
 		return COMMUNICATION_FAIL;
@@ -440,31 +438,31 @@ double driver::sensors::bme280::barometer::get_humidity_data(struct raw_data raw
 
 int8_t driver::sensors::bme280::barometer::get_calibration_data(struct calibration_data& calibration_data)
 {
-	std::unique_ptr<uint8_t[]> calib_data(new uint8_t[TEMPERATURE_PRESSURE_CALIB_DATA_LENGTH]{ 0 });
+	uint8_t calib_data[TEMPERATURE_PRESSURE_CALIB_DATA_LENGTH] = { 0 };
 
-	if (m_read_function(m_file_handle, TEMPERATURE_CALIBRATION_ADDR_1, calib_data, TEMPERATURE_PRESSURE_CALIB_DATA_LENGTH) != OK)
+	if (m_read_function(m_file_handle, TEMPERATURE_CALIBRATION_REG_1, calib_data, TEMPERATURE_PRESSURE_CALIB_DATA_LENGTH) != OK)
 	{
 		std::cerr << "BME280 [get_calibration_data] Error: Could not read temperature and pressure calibration data" << std::endl;
 		return COMMUNICATION_FAIL;
 	}
 
-	calibration_data.temperature_calibration_addr_1 = (uint16_t)((calib_data[1] << 8) | calib_data[0]);
-	calibration_data.temperature_calibration_addr_2 = (int16_t)(((uint16_t)calib_data[3] << 8) | (uint16_t)calib_data[2]);
-	calibration_data.temperature_calibration_addr_3 = (int16_t)(((uint16_t)calib_data[5] << 8) | (uint16_t)calib_data[4]);
+	calibration_data.temperature_calibration_reg_1 = (uint16_t)((calib_data[1] << 8) | calib_data[0]);
+	calibration_data.temperature_calibration_reg_2 = (int16_t)(((uint16_t)calib_data[3] << 8) | (uint16_t)calib_data[2]);
+	calibration_data.temperature_calibration_reg_3 = (int16_t)(((uint16_t)calib_data[5] << 8) | (uint16_t)calib_data[4]);
 
-	calibration_data.pressure_calibration_addr_1 = (uint16_t)((calib_data[7] << 8) | calib_data[6]);
-	calibration_data.pressure_calibration_addr_2 = (int16_t)(((uint16_t)calib_data[9] << 8) | (uint16_t)calib_data[8]);
-	calibration_data.pressure_calibration_addr_3 = (int16_t)(((uint16_t)calib_data[11] << 8) | (uint16_t)calib_data[10]);
-	calibration_data.pressure_calibration_addr_4 = (int16_t)(((uint16_t)calib_data[13] << 8) | (uint16_t)calib_data[12]);
-	calibration_data.pressure_calibration_addr_5 = (int16_t)(((uint16_t)calib_data[15] << 8) | (uint16_t)calib_data[14]);
-	calibration_data.pressure_calibration_addr_6 = (int16_t)(((uint16_t)calib_data[17] << 8) | (uint16_t)calib_data[16]);
-	calibration_data.pressure_calibration_addr_7 = (int16_t)(((uint16_t)calib_data[19] << 8) | (uint16_t)calib_data[18]);
-	calibration_data.pressure_calibration_addr_8 = (int16_t)(((uint16_t)calib_data[21] << 8) | (uint16_t)calib_data[20]);
-	calibration_data.pressure_calibration_addr_9 = (int16_t)(((uint16_t)calib_data[23] << 8) | (uint16_t)calib_data[22]);
+	calibration_data.pressure_calibration_reg_1 = (uint16_t)((calib_data[7] << 8) | calib_data[6]);
+	calibration_data.pressure_calibration_reg_2 = (int16_t)(((uint16_t)calib_data[9] << 8) | (uint16_t)calib_data[8]);
+	calibration_data.pressure_calibration_reg_3 = (int16_t)(((uint16_t)calib_data[11] << 8) | (uint16_t)calib_data[10]);
+	calibration_data.pressure_calibration_reg_4 = (int16_t)(((uint16_t)calib_data[13] << 8) | (uint16_t)calib_data[12]);
+	calibration_data.pressure_calibration_reg_5 = (int16_t)(((uint16_t)calib_data[15] << 8) | (uint16_t)calib_data[14]);
+	calibration_data.pressure_calibration_reg_6 = (int16_t)(((uint16_t)calib_data[17] << 8) | (uint16_t)calib_data[16]);
+	calibration_data.pressure_calibration_reg_7 = (int16_t)(((uint16_t)calib_data[19] << 8) | (uint16_t)calib_data[18]);
+	calibration_data.pressure_calibration_reg_8 = (int16_t)(((uint16_t)calib_data[21] << 8) | (uint16_t)calib_data[20]);
+	calibration_data.pressure_calibration_reg_9 = (int16_t)(((uint16_t)calib_data[23] << 8) | (uint16_t)calib_data[22]);
 	//calib_data[24] (0xA0) is not needed
-	calibration_data.humidity_calibration_addr_1 = calib_data[25];
+	calibration_data.humidity_calibration_reg_1 = calib_data[25];
 
-	if (m_read_function(m_file_handle, HUMIDITY_CALIBRATION_ADDR_2, calib_data, HUMIDITY_CALIB_DATA_LENGTH) != OK)
+	if (m_read_function(m_file_handle, HUMIDITY_CALIBRATION_REG_2, calib_data, HUMIDITY_CALIB_DATA_LENGTH) != OK)
 	{
 		std::cerr << "BME280 [get_calibration_data] Error: Could not read humidity calibration data" << std::endl;
 		return COMMUNICATION_FAIL;
@@ -475,20 +473,20 @@ int8_t driver::sensors::bme280::barometer::get_calibration_data(struct calibrati
 	int16_t dig_h5_lsb;
 	int16_t dig_h5_msb;
 
-	calibration_data.humidity_calibration_addr_2 = (int16_t)(((uint16_t)calib_data[1] << 8) | (uint16_t)calib_data[0]);
-	calibration_data.humidity_calibration_addr_3 = calib_data[2];
+	calibration_data.humidity_calibration_reg_2 = (int16_t)(((uint16_t)calib_data[1] << 8) | (uint16_t)calib_data[0]);
+	calibration_data.humidity_calibration_reg_3 = calib_data[2];
 	dig_h4_msb = (int16_t)(calib_data[3] * 16);
 	dig_h4_lsb = (int16_t)(calib_data[4] & 0x0F);
-	calibration_data.humidity_calibration_addr_4 = dig_h4_msb | dig_h4_lsb;
+	calibration_data.humidity_calibration_reg_4 = dig_h4_msb | dig_h4_lsb;
 	dig_h5_msb = (int16_t)(calib_data[5] * 16);
 	dig_h5_lsb = (int16_t)(calib_data[4] >> 4);
-	calibration_data.humidity_calibration_addr_5 = dig_h5_msb | dig_h5_lsb;
-	calibration_data.humidity_calibration_addr_6 = (int8_t)calib_data[6];
+	calibration_data.humidity_calibration_reg_5 = dig_h5_msb | dig_h5_lsb;
+	calibration_data.humidity_calibration_reg_6 = (int8_t)calib_data[6];
 
 	return OK;
 }
 
-int8_t driver::sensors::bme280::barometer::parse_raw_data(std::unique_ptr<uint8_t[]>& read_data, std::unique_ptr<struct raw_data>& raw_data)
+int8_t driver::sensors::bme280::barometer::parse_raw_data(uint8_t* read_data, std::shared_ptr<struct raw_data>& raw_data)
 {
 	uint32_t data_xlsb = 0;
 	uint32_t data_lsb = 0;
@@ -511,19 +509,19 @@ int8_t driver::sensors::bme280::barometer::parse_raw_data(std::unique_ptr<uint8_
 	return OK;
 }
 
-int8_t driver::sensors::bme280::barometer::get_all_raw_data(std::unique_ptr<uint8_t[]>& all_data)
+int8_t driver::sensors::bme280::barometer::get_all_raw_data(uint8_t* all_data)
 {
-	std::unique_ptr<uint8_t[]>reg_data(new uint8_t[COMPLETE_FILE_LENGTH]{ 0 });
+	uint8_t reg_data[COMPLETE_FILE_LENGTH] = { 0 };
 	if (m_read_function(m_file_handle, FILE_BEGIN, reg_data, COMPLETE_FILE_LENGTH) != OK)
 	{
 		std::cerr << "BME280 [get_all_raw_data] Error: Could not read all file data" << std::endl;
 		return COMMUNICATION_FAIL;
 	}
-	all_data = std::move(reg_data);
+	all_data = reg_data;
 
 	for (int i = 0; i <= COMPLETE_FILE_LENGTH; ++i)
 	{
-		std::cout << i << ": " << (int)all_data.get()[i] << std::endl;
+		std::cout << i << ": " << (int)all_data[i] << std::endl;
 	}
 
 	return OK;
@@ -535,10 +533,10 @@ double driver::sensors::bme280::barometer::compensate_temperature(struct calibra
 	double var2;
 	double temperature;
 
-	var1 = ((double)raw_temperature) / 16384.0 - ((double)calibration.temperature_calibration_addr_1) / 1024.0;
-	var1 = var1 * ((double)calibration.temperature_calibration_addr_2);
-	var2 = (((double)raw_temperature) / 131072.0 - ((double)calibration.temperature_calibration_addr_1) / 8192.0);
-	var2 = (var2 * var2) * ((double)calibration.temperature_calibration_addr_3);
+	var1 = ((double)raw_temperature) / 16384.0 - ((double)calibration.temperature_calibration_reg_1) / 1024.0;
+	var1 = var1 * ((double)calibration.temperature_calibration_reg_2);
+	var2 = (((double)raw_temperature) / 131072.0 - ((double)calibration.temperature_calibration_reg_1) / 8192.0);
+	var2 = (var2 * var2) * ((double)calibration.temperature_calibration_reg_3);
 	calibration.fine_temperature = (int32_t)(var1 + var2);
 	temperature = (var1 + var2) / 5120.0;
 	if (temperature < TEMPERATURE_MIN)
@@ -561,21 +559,21 @@ double driver::sensors::bme280::barometer::compensate_pressure(struct calibratio
 	double pressure;
 
 	var1 = ((double)calibration.fine_temperature / 2.0) - 64000.0;
-	var2 = var1 * var1 * (double)calibration.pressure_calibration_addr_6 / 32768.0;
-	var2 = var2 + var1 * (double)calibration.pressure_calibration_addr_5 * 2.0;
-	var2 = var2 / 4.0 + (double)calibration.pressure_calibration_addr_4 * 65536.0;
-	var3 = ((double)calibration.pressure_calibration_addr_3 * var1 * var1) / 524288.0;
-	var1 = (var3 + (double)calibration.pressure_calibration_addr_2 * var1) / 524288.0;
-	var1 = (1.0 + var1 / 32768.0) * (double)calibration.pressure_calibration_addr_1;
+	var2 = var1 * var1 * (double)calibration.pressure_calibration_reg_6 / 32768.0;
+	var2 = var2 + var1 * (double)calibration.pressure_calibration_reg_5 * 2.0;
+	var2 = var2 / 4.0 + (double)calibration.pressure_calibration_reg_4 * 65536.0;
+	var3 = ((double)calibration.pressure_calibration_reg_3 * var1 * var1) / 524288.0;
+	var1 = (var3 + (double)calibration.pressure_calibration_reg_2 * var1) / 524288.0;
+	var1 = (1.0 + var1 / 32768.0) * (double)calibration.pressure_calibration_reg_1;
 
 	/* avoid exception caused by division by zero */
 	if (var1 > (0.0))
 	{
 		pressure = 1048576.0 - (double)raw_pressure;
 		pressure = (pressure - var2 / 4096.0) * 6250.0 / var1;
-		var1 = (double)calibration.pressure_calibration_addr_9 * pressure * pressure / 2147483648.0;
-		var2 = pressure * (double)calibration.pressure_calibration_addr_8 / 32768.0;
-		pressure = pressure + (var1 + var2 + (double)calibration.pressure_calibration_addr_7) / 16.0;
+		var1 = (double)calibration.pressure_calibration_reg_9 * pressure * pressure / 2147483648.0;
+		var2 = pressure * (double)calibration.pressure_calibration_reg_8 / 32768.0;
+		pressure = pressure + (var1 + var2 + (double)calibration.pressure_calibration_reg_7) / 16.0;
 		if (pressure < PRESSURE_MIN)
 		{
 			pressure = PRESSURE_MIN;
@@ -604,13 +602,13 @@ double driver::sensors::bme280::barometer::compensate_humidity(struct calibratio
 	double var6;
 
 	var1 = ((double)calibration.fine_temperature) - 76800.0;
-	var2 = (((double)calibration.humidity_calibration_addr_4) * 64.0 + (((double)calibration.humidity_calibration_addr_5) / 16384.0) * var1);
+	var2 = (((double)calibration.humidity_calibration_reg_4) * 64.0 + (((double)calibration.humidity_calibration_reg_5) / 16384.0) * var1);
 	var3 = raw_humidity - var2;
-	var4 = ((double)calibration.humidity_calibration_addr_2) / 65536.0;
-	var5 = (1.0 + (((double)calibration.humidity_calibration_addr_3) / 67108864.0) * var1);
-	var6 = 1.0 + (((double)calibration.humidity_calibration_addr_6) / 67108864.0) * var1 * var5;
+	var4 = ((double)calibration.humidity_calibration_reg_2) / 65536.0;
+	var5 = (1.0 + (((double)calibration.humidity_calibration_reg_3) / 67108864.0) * var1);
+	var6 = 1.0 + (((double)calibration.humidity_calibration_reg_6) / 67108864.0) * var1 * var5;
 	var6 = var3 * var4 * (var5 * var6);
-	humidity = var6 * (1.0 - ((double)calibration.humidity_calibration_addr_1) * var6 / 524288.0);
+	humidity = var6 * (1.0 - ((double)calibration.humidity_calibration_reg_1) * var6 / 524288.0);
 
 	if (humidity > HUMIDITY_MAX)
 	{
@@ -626,7 +624,7 @@ double driver::sensors::bme280::barometer::compensate_humidity(struct calibratio
 
 int8_t driver::sensors::bme280::barometer::calculate_wait_time(double& time)
 {
-	std::unique_ptr<struct settings_data> settings = std::make_unique<struct settings_data>(m_device.settings);
+	std::shared_ptr<struct settings_data> settings = std::make_shared<struct settings_data>(m_device.settings);
 	if (get_settings(settings) != OK)
 	{
 		std::cerr << "BME280 [calculate_wait_time] Error: Could not read device settings" << std::endl;
@@ -641,7 +639,7 @@ void driver::sensors::bme280::barometer::sleep_until_ready()
 	usleep((__useconds_t)(m_device.wait_time * 1000));
 }
 
-void driver::sensors::bme280::barometer::parse_settings(std::unique_ptr<uint8_t[]>& read_data, std::unique_ptr<struct settings_data>& settings)
+void driver::sensors::bme280::barometer::parse_settings(uint8_t* read_data, std::shared_ptr<struct settings_data>& settings)
 {
 	settings->humidity_oversampling = (read_data[0] & ((HUMIDITY_MASK)));
 	settings->pressure_oversampling = ((read_data[2] & ((PRESSURE_MASK))) >> ((PRESSURE_POS)));
@@ -671,14 +669,4 @@ bool driver::sensors::bme280::barometer::are_settings_changed(uint8_t old_settin
 	{
 		return false;
 	}
-}
-
-int8_t driver::sensors::bme280::barometer::null_check(void* pointer)
-{
-	if (pointer)
-	{
-		return OK;
-	}
-
-	return NULL_PTR;
 }

--- a/PiDashboardBackend/src/drivers/bme280_barometer_constants.h
+++ b/PiDashboardBackend/src/drivers/bme280_barometer_constants.h
@@ -11,43 +11,43 @@ namespace driver
 			static constexpr const uint8_t CHIP_ID = 0X60;
 			static constexpr const uint8_t STATUS_DURING_UPDATE = 0X01;
 
-			static constexpr const uint8_t SENSOR_PRIMARY_I2C_ADDR = 0x76;
-			static constexpr const uint8_t SENSOR_SECONDARY_I2C_ADDR = 0x77;
+			static constexpr const uint8_t SENSOR_PRIMARY_I2C_REG = 0x76;
+			static constexpr const uint8_t SENSOR_SECONDARY_I2C_REG = 0x77;
 
 			// Temperature addresses
-			static constexpr const uint16_t TEMPERATURE_CALIBRATION_ADDR_1 = 0x88;
-			static constexpr const int16_t TEMPERATURE_CALIBRATION_ADDR_2 = 0x8A;
-			static constexpr const int16_t TEMPERATURE_CALIBRATION_ADDR_3 = 0x8C;
+			static constexpr const uint16_t TEMPERATURE_CALIBRATION_REG_1 = 0x88;
+			static constexpr const int16_t TEMPERATURE_CALIBRATION_REG_2 = 0x8A;
+			static constexpr const int16_t TEMPERATURE_CALIBRATION_REG_3 = 0x8C;
 
 			// Pressure addresses
-			static constexpr const uint16_t PRESSURE_CALIBRATION_ADDR_1 = 0x8E;
-			static constexpr const int16_t PRESSURE_CALIBRATION_ADDR_2 = 0x90;
-			static constexpr const int16_t PRESSURE_CALIBRATION_ADDR_3 = 0x92;
-			static constexpr const int16_t PRESSURE_CALIBRATION_ADDR_4 = 0x94;
-			static constexpr const int16_t PRESSURE_CALIBRATION_ADDR_5 = 0x96;
-			static constexpr const int16_t PRESSURE_CALIBRATION_ADDR_6 = 0x98;
-			static constexpr const int16_t PRESSURE_CALIBRATION_ADDR_7 = 0x9A;
-			static constexpr const int16_t PRESSURE_CALIBRATION_ADDR_8 = 0x9C;
-			static constexpr const int16_t PRESSURE_CALIBRATION_ADDR_9 = 0x9E;
+			static constexpr const uint16_t PRESSURE_CALIBRATION_REG_1 = 0x8E;
+			static constexpr const int16_t PRESSURE_CALIBRATION_REG_2 = 0x90;
+			static constexpr const int16_t PRESSURE_CALIBRATION_REG_3 = 0x92;
+			static constexpr const int16_t PRESSURE_CALIBRATION_REG_4 = 0x94;
+			static constexpr const int16_t PRESSURE_CALIBRATION_REG_5 = 0x96;
+			static constexpr const int16_t PRESSURE_CALIBRATION_REG_6 = 0x98;
+			static constexpr const int16_t PRESSURE_CALIBRATION_REG_7 = 0x9A;
+			static constexpr const int16_t PRESSURE_CALIBRATION_REG_8 = 0x9C;
+			static constexpr const int16_t PRESSURE_CALIBRATION_REG_9 = 0x9E;
 
 			// Humidity addresses
-			static constexpr const uint8_t HUMIDITY_CALIBRATION_ADDR_1 = 0xA1;
-			static constexpr const int16_t HUMIDITY_CALIBRATION_ADDR_2 = 0xE1;
-			static constexpr const uint8_t HUMIDITY_CALIBRATION_ADDR_3 = 0xE3;
-			static constexpr const int16_t HUMIDITY_CALIBRATION_ADDR_4 = 0xE4;
-			static constexpr const int16_t HUMIDITY_CALIBRATION_ADDR_5 = 0xE5;
-			static constexpr const int8_t HUMIDITY_CALIBRATION_ADDR_6 = (int8_t)0xE7;
+			static constexpr const uint8_t HUMIDITY_CALIBRATION_REG_1 = 0xA1;
+			static constexpr const int16_t HUMIDITY_CALIBRATION_REG_2 = 0xE1;
+			static constexpr const uint8_t HUMIDITY_CALIBRATION_REG_3 = 0xE3;
+			static constexpr const int16_t HUMIDITY_CALIBRATION_REG_4 = 0xE4;
+			static constexpr const int16_t HUMIDITY_CALIBRATION_REG_5 = 0xE5;
+			static constexpr const int8_t HUMIDITY_CALIBRATION_REG_6 = (int8_t)0xE7;
 
 			// General addresses
 			static constexpr const uint8_t FILE_BEGIN = 0X88;
-			static constexpr const uint8_t CHIP_ID_ADDR = 0XD0;
-			static constexpr const uint8_t SOFT_RESET_ADDR = 0XE0;
-			static constexpr const uint8_t MEASUREMENT_OVERSAMPLING_ADDR = 0XF4;
-			static constexpr const uint8_t MODE_ADDR = 0XF4;
-			static constexpr const uint8_t HUMIDITY_OVERSAMPLING_ADDR = 0XF2;
-			static constexpr const uint8_t CONFIG_ADDR = 0XF5;
-			static constexpr const uint8_t STATUS_ADDR = 0XF3;
-			static constexpr const uint8_t DATA_ADDR = 0XF7;
+			static constexpr const uint8_t CHIP_ID_REG = 0XD0;
+			static constexpr const uint8_t SOFT_RESET_REG = 0XE0;
+			static constexpr const uint8_t MEASUREMENT_OVERSAMPLING_REG = 0XF4;
+			static constexpr const uint8_t MODE_REG = 0XF4;
+			static constexpr const uint8_t HUMIDITY_OVERSAMPLING_REG = 0XF2;
+			static constexpr const uint8_t CONFIG_REG = 0XF5;
+			static constexpr const uint8_t STATUS_REG = 0XF3;
+			static constexpr const uint8_t DATA_REG = 0XF7;
 
 			// Settings selection
 			static constexpr const uint8_t PRESSURE_SETTING_SELECTION = 1;
@@ -90,13 +90,8 @@ namespace driver
 
 			// Return codes (Warning, Ok, Error)
 			static constexpr const int8_t INVALID_OSR_WARNING = 1;
-			static constexpr const int8_t OK = 0;
-			static constexpr const int8_t NULL_PTR = -1;
-			static constexpr const int8_t DEVICE_NOT_FOUND = -2;
-			static constexpr const int8_t INVALID_LENGTH = -3;
-			static constexpr const int8_t COMMUNICATION_FAIL = -4;
-			static constexpr const int8_t SLEEP_MODE_FAIL = -5;
-			static constexpr const int8_t NVM_COPY_FAILED = -6;
+			static constexpr const int8_t SLEEP_MODE_FAIL = -10;
+			static constexpr const int8_t NVM_COPY_FAILED = -11;
 		}
 	}
 }

--- a/PiDashboardBackend/src/drivers/bme280_barometer_definitions.h
+++ b/PiDashboardBackend/src/drivers/bme280_barometer_definitions.h
@@ -47,24 +47,24 @@ namespace driver
 			struct calibration_data
 			{
 				int32_t fine_temperature;
-				uint16_t temperature_calibration_addr_1;
-				int16_t temperature_calibration_addr_2;
-				int16_t temperature_calibration_addr_3;
-				uint16_t pressure_calibration_addr_1;
-				int16_t pressure_calibration_addr_2;
-				int16_t pressure_calibration_addr_3;
-				int16_t pressure_calibration_addr_4;
-				int16_t pressure_calibration_addr_5;
-				int16_t pressure_calibration_addr_6;
-				int16_t pressure_calibration_addr_7;
-				int16_t pressure_calibration_addr_8;
-				int16_t pressure_calibration_addr_9;
-				uint8_t humidity_calibration_addr_1;
-				int16_t humidity_calibration_addr_2;
-				uint8_t humidity_calibration_addr_3;
-				int16_t humidity_calibration_addr_4;
-				int16_t humidity_calibration_addr_5;
-				int8_t humidity_calibration_addr_6;
+				uint16_t temperature_calibration_reg_1;
+				int16_t temperature_calibration_reg_2;
+				int16_t temperature_calibration_reg_3;
+				uint16_t pressure_calibration_reg_1;
+				int16_t pressure_calibration_reg_2;
+				int16_t pressure_calibration_reg_3;
+				int16_t pressure_calibration_reg_4;
+				int16_t pressure_calibration_reg_5;
+				int16_t pressure_calibration_reg_6;
+				int16_t pressure_calibration_reg_7;
+				int16_t pressure_calibration_reg_8;
+				int16_t pressure_calibration_reg_9;
+				uint8_t humidity_calibration_reg_1;
+				int16_t humidity_calibration_reg_2;
+				uint8_t humidity_calibration_reg_3;
+				int16_t humidity_calibration_reg_4;
+				int16_t humidity_calibration_reg_5;
+				int8_t humidity_calibration_reg_6;
 			};
 
 			struct settings_data
@@ -85,8 +85,6 @@ namespace driver
 
 			struct bme280_device
 			{
-				uint8_t chip_id;
-				uint8_t dev_id;
 				struct calibration_data calibration_data;
 				struct settings_data settings;
 				double wait_time;

--- a/PiDashboardBackend/src/drivers/ccs811_co2.cpp
+++ b/PiDashboardBackend/src/drivers/ccs811_co2.cpp
@@ -1,0 +1,797 @@
+#include "ccs811_co2.h"
+
+int8_t driver::sensors::ccs811::co2::init(uint8_t device_reg,
+	std::function<int8_t(int, uint8_t, uint8_t*, uint16_t)> read_function,
+	std::function<int8_t(int, uint8_t, const uint8_t*, uint16_t)> write_function,
+	std::function<int8_t(const std::string, uint8_t, int&)> open_device_function,
+	std::function<int8_t(int&)> close_device_function)
+{
+	m_dev_id = device_reg;
+	m_read_function = read_function;
+	m_write_function = write_function;
+	m_open_device_function = open_device_function;
+	m_close_device_function = close_device_function;
+
+	if (m_open_device_function(manager::i2c_manager::DEFAULT_PI_I2C_PATH, m_dev_id, m_file_handle) != OK)
+	{
+		std::cerr << "CCS881 [init] Error: Could not establish connection with device." << std::endl;
+		return DEVICE_NOT_FOUND;
+	}
+
+	std::shared_ptr<struct ccs811_device_info> info = std::make_shared<struct ccs811_device_info>();
+	if (get_device_information(info) != OK)
+	{
+		std::cerr << "CCS881 [init] Error: Could not read device information." << std::endl;
+		return DEVICE_NOT_FOUND;
+	}
+
+	return OK;
+}
+
+int8_t driver::sensors::ccs811::co2::init(bool use_power_save_mode, int wake_gpio_pin_nr, int int_gpio_pin_nr,
+	std::function<void(uint16_t, uint16_t)> data_callback, uint8_t device_reg,
+	std::function<int8_t(int, uint8_t, uint8_t*, uint16_t)> read_function,
+	std::function<int8_t(int, uint8_t, const uint8_t*, uint16_t)> write_function,
+	std::function<int8_t(const std::string, uint8_t, int&)> open_device_function,
+	std::function<int8_t(int&)> close_device_function)
+{
+	m_int_gpio_pin_nr = int_gpio_pin_nr;
+	m_use_power_safe_mode = use_power_save_mode;
+	m_wake_gpio_pin = wake_gpio_pin_nr;
+	m_data_callback = data_callback;
+
+	if (wiringPiSetup() != OK)
+	{
+		std::cerr << "CCS881 [init] Error: Could not initialize wiringPi." << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	pinMode(m_int_gpio_pin_nr, INPUT);
+	pinMode(m_wake_gpio_pin, OUTPUT);
+	unwake_device();
+
+	if (init(device_reg, read_function, write_function, open_device_function, close_device_function) != OK)
+	{
+		std::cerr << "CCS881 [init] Error: Could not establish connection with device." << std::endl;
+		return DEVICE_NOT_FOUND;
+	}
+	return OK;
+}
+
+int8_t driver::sensors::ccs811::co2::close()
+{
+	return m_close_device_function(m_file_handle);
+}
+
+int8_t driver::sensors::ccs811::co2::toggle_power_safe_mode(bool use_power_safe_mode)
+{
+	m_use_power_safe_mode = use_power_safe_mode;
+
+	if (!m_use_power_safe_mode) // Deactivate power safe mode
+	{
+		wake_device(); // Just put the pin to low and leave it. This way the processor is always running
+	}
+	return OK;
+}
+
+int8_t driver::sensors::ccs811::co2::start()
+{
+	std::shared_ptr<struct ccs811_status> status = std::make_shared<struct ccs811_status>();
+	if (get_status_information(status) != OK)
+	{
+		std::cerr << "CCS881 [start] Error: Could not read status information from the device before start request." << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	if (status->current_state == ccs811_state::BOOT)
+	{
+		if (!status->firmware_loaded) // Firmware state not validated. Check it
+		{
+			bool fw_state = false;
+			if (verify_firmware(fw_state) != OK)
+			{
+				std::cerr << "CCS881 [start] Error: The installed firmware is invalid or could not be validated." << std::endl;
+				return DEVICE_ERROR;
+			}
+		}
+
+		uint8_t start_byte = 0xF4;
+		if (m_use_power_safe_mode) wake_device();
+		int8_t i2c_res = m_write_function(m_file_handle, APP_START_BOOT_REG, &start_byte, 0);
+		if (m_use_power_safe_mode) unwake_device();
+
+		if (i2c_res != OK)
+		{
+			std::cerr << "CCS881 [start] Error: Could not start device." << std::endl;
+			return DEVICE_ERROR;
+		}
+
+		if (get_status_information(status) != OK)
+		{
+			std::cerr << "CCS881 [start] Error: Could not read status information from the device after start request." << std::endl;
+			return COMMUNICATION_FAIL;
+		}
+
+		if (status->current_state != ccs811_state::READY)
+		{
+			std::cerr << "CCS881 [start] Error: Could not start the device." << std::endl;
+			return DEVICE_ERROR;
+		}
+
+		std::shared_ptr<struct ccs811_mode_info> current_mode = std::make_shared<struct ccs811_mode_info>();
+		if (get_operation_mode_information(current_mode) != OK)
+		{
+			std::cerr << "CCS881 [start] Error: Could not read mode information from the device after start request." << std::endl;
+			return COMMUNICATION_FAIL;
+		}
+		m_current_mode = current_mode->current_mode;
+
+		return OK;
+	}
+	else
+	{
+		std::cout << "CCS881 [start] Warning: Device is already started and ready to measure. Nothing has been done through this method call." << std::endl;
+		return WARNING;
+	}
+}
+
+int8_t driver::sensors::ccs811::co2::get_status_information(std::shared_ptr<struct ccs811_status>& status)
+{
+	if (null_check(status.get()) != OK)
+	{
+		std::cerr << "CCS881 [get_status_information] Error: Status input struct is null" << std::endl;
+		return NULL_PTR;
+	}
+
+	uint8_t raw_status;
+	if (m_use_power_safe_mode) wake_device();
+	int8_t i2c_res = m_read_function(m_file_handle, STATUS_REG, &raw_status, STATUS_LEN);
+	if (m_use_power_safe_mode) unwake_device();
+	if (i2c_res != OK)
+	{
+		std::cerr << "CCS881 [get_status_information] Error: Could not read status information from the device." << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	// Check error bit
+	if (is_bit_set(raw_status, 0))
+	{
+		status->has_error = true;
+		uint8_t error_code;
+		if (read_error(error_code) != OK)
+		{
+			status->error_message.push_back("CCS881 [get_status_information] Error: The device has an error that could not be read.");
+			std::cerr << "CCS881 [get_status_information] Error: The device has an error that could not be read." << std::endl;
+			return COMMUNICATION_FAIL;
+		}
+		else
+		{
+			if (is_bit_set(error_code, 0)) // WRITE_REG_INVALID
+			{
+				status->error_message.push_back("CCS881 [get_status_information] Error WRITE_REG_INVALID: The CCS811 received an I²C write"
+					"request addressed to this station but with invalid register address ID.");
+			}
+			if (is_bit_set(error_code, 1)) // READ_REG_INVALID
+			{
+				status->error_message.push_back("CCS881 [get_status_information] Error READ_REG_INVALID: "
+					"The CCS811 received an I²C read request to a mailbox ID that is invalid");
+			}
+			if (is_bit_set(error_code, 2)) // MEASUREMODE_INVALID
+			{
+				status->error_message.push_back("CCS881 [get_status_information] Error MEASUREMODE_INVALID: "
+					"The CCS811 received an I²C request to write an unsupported mode to	MEAS_MODE");
+			}
+			if (is_bit_set(error_code, 3)) // MAX_RESISTANCE
+			{
+				status->error_message.push_back("CCS881 [get_status_information] Error: MAX_RESISTANCE: "
+					"The sensor resistance measurement has reached or exceeded the maximum range");
+			}
+			if (is_bit_set(error_code, 4)) // HEATER_FAULT
+			{
+				status->error_message.push_back("CCS881 [get_status_information] Error: HEATER_FAULT: "
+					"The Heater current in the CCS811 is not in range");
+			}
+			if (is_bit_set(error_code, 5)) // HEATER_SUPPLY_ERROR
+			{
+				status->error_message.push_back("CCS881 [get_status_information] Error: HEATER_SUPPLY_ERROR: "
+					"The Heater voltage is not being applied correctly");
+			}
+		}
+	}
+
+	status->raw_status_info = raw_status;
+	status->data_ready = is_bit_set(raw_status, 3);
+	status->firmware_loaded = is_bit_set(raw_status, 4);
+	status->current_state = is_bit_set(raw_status, 7) ? ccs811_state::READY : ccs811_state::BOOT;
+	return OK;
+}
+
+int8_t driver::sensors::ccs811::co2::get_device_information(std::shared_ptr<struct ccs811_device_info>& info)
+{
+	uint8_t hw_id;
+	if (m_use_power_safe_mode) wake_device();
+	if (m_read_function(m_file_handle, HARDWARE_ID_REG, &hw_id, HARDWARE_ID_LEN) != OK)
+	{
+		if (m_use_power_safe_mode) unwake_device();
+		std::cerr << "CCS881 [get_device_information] Error: Could not read hardware chip id from the device." << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+	if (hw_id != HARDWARE_ID_VALUE)
+	{
+		if (m_use_power_safe_mode) unwake_device();
+		std::cerr << "CCS881 [get_device_information] Error: Wrong hardware id. Awaited 0x81 but got 0x" << std::hex << hw_id << std::dec <<
+			" from the device." << std::endl;
+		return DEVICE_NOT_FOUND;
+	}
+
+	uint8_t hw_vers_raw;
+	if (m_read_function(m_file_handle, HARDWARE_VERSION_REG, &hw_vers_raw, HARDWARE_VERSION_LEN) != OK)
+	{
+		if (m_use_power_safe_mode) unwake_device();
+		std::cerr << "CCS881 [get_device_information] Error: Could not read hardware version from the device." << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	uint8_t fw_vers_raw[2] = { 0, 0 };
+	if (m_read_function(m_file_handle, FIRMWARE_VERSION_REG, fw_vers_raw, FIRMWARE_VERSION_LEN) != OK)
+	{
+		if (m_use_power_safe_mode) unwake_device();
+		std::cerr << "CCS881 [get_device_information] Error: Could not read firmware version from the device." << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	uint8_t app_vers_raw[2] = { 0, 0 };
+	if (m_read_function(m_file_handle, APPLICATION_VERSION_REG, app_vers_raw, APPLICATION_VERSION_LEN) != OK)
+	{
+		if (m_use_power_safe_mode) unwake_device();
+		std::cerr << "CCS881 [get_device_information] Error: Could not read application version from the device." << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+	if (m_use_power_safe_mode) unwake_device();
+
+	info->device_id = m_dev_id;
+	info->hardware_id = hw_id;
+	info->hardware_version = std::to_string((int)value_of_bits(hw_vers_raw, 4, 7)) + "." + std::to_string((int)value_of_bits(hw_vers_raw, 0, 3));
+	info->firmware_version = std::to_string((int)value_of_bits(fw_vers_raw[0], 4, 7)) + "." + std::to_string((int)value_of_bits(fw_vers_raw[0], 0, 3)) + "." + std::to_string((int)fw_vers_raw[1]);
+	info->application_version = std::to_string((int)value_of_bits(app_vers_raw[0], 4, 7)) + "." + std::to_string((int)value_of_bits(app_vers_raw[0], 0, 3)) + "." + std::to_string((int)app_vers_raw[1]);
+
+	return OK;
+}
+
+int8_t driver::sensors::ccs811::co2::get_operation_mode_information(std::shared_ptr<struct ccs811_mode_info>& mode)
+{
+	if (check_device_mode() == OK)
+	{
+		uint8_t raw_mode;
+		if (m_use_power_safe_mode) wake_device();
+		int8_t i2c_res = m_read_function(m_file_handle, MODE_REG, &raw_mode, MODE_LEN);
+		if (m_use_power_safe_mode) unwake_device();
+		if (i2c_res != OK)
+		{
+			std::cerr << "CCS881 [get_operation_mode_information] Error: Could not read mode information from the device." << std::endl;
+			return COMMUNICATION_FAIL;
+		}
+
+		mode->raw_mode_info = raw_mode;
+		uint8_t mode_value = value_of_bits(raw_mode, 4, 6);
+		switch (mode_value)
+		{
+		case 0:
+			mode->current_mode = ccs811_operation_mode::SLEEP;
+			break;
+		case 1:
+			mode->current_mode = ccs811_operation_mode::CONSTANT_POWER_1_S;
+			break;
+		case 2:
+			mode->current_mode = ccs811_operation_mode::PULSE_10_S;
+			break;
+		case 3:
+			mode->current_mode = ccs811_operation_mode::PULSE_60_S;
+			break;
+		case 4:
+			mode->current_mode = ccs811_operation_mode::CONSTANT_POWER_250_MS;
+			break;
+		default:
+			std::cerr << "CCS881 [get_operation_mode_information] Error: The device seems to have an invalid mode: " << mode_value << std::endl;
+			return DEVICE_ERROR;
+		}
+		mode->interrupt_gerneration = is_bit_set(raw_mode, 3);
+		mode->use_threshold = is_bit_set(raw_mode, 2);
+
+		return OK;
+	}
+
+	return WRONG_MODE_WARNING;
+}
+
+int8_t driver::sensors::ccs811::co2::set_operation_mode(enum ccs811_operation_mode mode, bool interrupt_mode, bool use_thresholds)
+{
+	if (check_device_mode() == OK)
+	{
+		std::shared_ptr<struct ccs811_mode_info> current_mode = std::make_shared<struct ccs811_mode_info>();
+		if (get_operation_mode_information(current_mode) != OK)
+		{
+			std::cerr << "CCS881 [set_operation_mode] Error: Could not read mode information from the device." << std::endl;
+			return COMMUNICATION_FAIL;
+		}
+
+		// If interrupt generation is currently on, should stay on and private fields for this purpose or uninitialized / set false.
+		if (current_mode->interrupt_gerneration && interrupt_mode && !m_use_interrupt_mode && m_interrupt_thread == nullptr)
+		{
+			// The device is in interrupt mode but our thread is not running...
+			// Could be caused through a software restart which did not power off the device.
+			start_interrupt_thread();
+		}
+
+		if (current_mode->current_mode == mode && current_mode->interrupt_gerneration == interrupt_mode && current_mode->use_threshold == use_thresholds)
+		{
+			// Nothing changes -> abort
+			m_current_mode = mode;
+			std::cout << "CCS881 [set_operation_mode] Warning: The device is already in mode '" << (int)mode << "'. Therefore this method call has no effect." << std::endl;
+			return WARNING;
+		}
+
+		if (current_mode->current_mode > mode&& mode != ccs811_operation_mode::SLEEP)
+		{
+			// Switch to a slower mode -> wait 10 minutes in idle mode first.
+			if (!set_bits(current_mode->raw_mode_info, SLEEP, MODE_MASK))
+			{
+				std::cerr << "CCS881 [set_operation_mode] Error: Could not write new mode to mode byte." << std::endl;
+				return BIT_MANIPULATION_ERROR;
+			}
+			if (!set_bit(current_mode->raw_mode_info, 3, 0))
+			{
+				std::cerr << "CCS881 [set_operation_mode] Error: Could not set interrupt mode to false in mode byte." << std::endl;
+				return BIT_MANIPULATION_ERROR;
+			}
+			if (!set_bit(current_mode->raw_mode_info, 2, 0))
+			{
+				std::cerr << "CCS881 [set_operation_mode] Error: Could not set threshold mode to false in mode byte." << std::endl;
+				return BIT_MANIPULATION_ERROR;
+			}
+
+			if (m_use_power_safe_mode) wake_device();
+			int8_t i2c_res = m_write_function(m_file_handle, MODE_REG, &current_mode->raw_mode_info, 1);
+			if (m_use_power_safe_mode) unwake_device();
+			if (i2c_res != OK)
+			{
+				std::cerr << "CCS881 [set_operation_mode] Error: Could not write new operation mode 'SLEEP' to device." << std::endl;
+				return DEVICE_ERROR;
+			}
+
+			if (m_use_interrupt_mode && m_interrupt_thread != nullptr)
+			{
+				stop_interrupt_thread();
+			}
+
+			m_current_mode = ccs811_operation_mode::SLEEP;
+			return MODE_SWITCH_WARNING;
+		}
+		else
+		{
+			// Switch to a faster mode or SLEEP mode -> can be instantly switched.
+			uint8_t new_mode;
+			switch (mode)
+			{
+			case ccs811_operation_mode::SLEEP:
+				new_mode = SLEEP;
+				break;
+			case ccs811_operation_mode::CONSTANT_POWER_1_S:
+				new_mode = CONSTANT_POWER_1_S;
+				break;
+			case ccs811_operation_mode::PULSE_10_S:
+				new_mode = PULSE_10_S;
+				break;
+			case ccs811_operation_mode::PULSE_60_S:
+				new_mode = PULSE_60_S;
+				break;
+			case ccs811_operation_mode::CONSTANT_POWER_250_MS:
+				new_mode = CONSTANT_POWER_250_MS;
+				break;
+			}
+
+			if (!set_bits(current_mode->raw_mode_info, new_mode, MODE_MASK))
+			{
+				std::cerr << "CCS881 [set_operation_mode] Error: Could not write new mode to mode byte." << std::endl;
+				return BIT_MANIPULATION_ERROR;
+			}
+			if (!set_bit(current_mode->raw_mode_info, 3, interrupt_mode))
+			{
+				std::cerr << "CCS881 [set_operation_mode] Error: Could not set interrupt mode to " << interrupt_mode << " in mode byte." << std::endl;
+				return BIT_MANIPULATION_ERROR;
+			}
+			if (!set_bit(current_mode->raw_mode_info, 2, use_thresholds))
+			{
+				std::cerr << "CCS881 [set_operation_mode] Error: Could not set threshold mode to " << use_thresholds << " in mode byte." << std::endl;
+				return BIT_MANIPULATION_ERROR;
+			}
+
+			if (m_use_power_safe_mode) wake_device();
+			int8_t i2c_res = m_write_function(m_file_handle, MODE_REG, &current_mode->raw_mode_info, 1);
+			if (m_use_power_safe_mode) unwake_device();
+			if (i2c_res != OK)
+			{
+				std::cerr << "CCS881 [set_operation_mode] Error: Could not write new operation mode '" << (int)mode << "' to device." << std::endl;
+				return DEVICE_ERROR;
+			}
+			m_current_mode = mode;
+
+			// Start / Stop interrupt threads
+			if (interrupt_mode && mode != ccs811_operation_mode::SLEEP)
+			{
+				start_interrupt_thread();
+			}
+			else
+			{
+				stop_interrupt_thread();
+			}
+			return OK;
+		}
+	}
+
+	return WRONG_MODE_WARNING;
+}
+
+int8_t driver::sensors::ccs811::co2::get_eCO2_data(uint16_t& eCO2)
+{
+	if (check_device_mode() == OK)
+	{
+		uint8_t raw_results[2] = { 0, 0 };
+		if (m_use_power_safe_mode) wake_device();
+		int8_t i2c_res = m_read_function(m_file_handle, RESULT_DATA_REG, raw_results, ECO2_LEN);
+		if (m_use_power_safe_mode) unwake_device();
+		if (i2c_res != OK)
+		{
+			std::cerr << "CCS881 [get_eCO2_data] Error: Could not read eCO2 data from the device." << std::endl;
+			return COMMUNICATION_FAIL;
+		}
+
+		eCO2 = (uint16_t)((raw_results[0] << 8) | raw_results[1]);
+		return OK;
+	}
+
+	return WRONG_MODE_WARNING;
+}
+
+int8_t driver::sensors::ccs811::co2::get_TVOC_data(uint16_t& TVOC)
+{
+	if (check_device_mode() == OK)
+	{
+		uint8_t raw_results[4] = { 0, 0, 0, 0 };
+		if (m_use_power_safe_mode) wake_device();
+		int8_t i2c_res = m_read_function(m_file_handle, RESULT_DATA_REG, raw_results, TVOC_LEN);
+		if (m_use_power_safe_mode) unwake_device();
+		if (i2c_res != OK)
+		{
+			std::cerr << "CCS881 [get_TVOC_data] Error: Could not read TVOC data from the device." << std::endl;
+			return COMMUNICATION_FAIL;
+		}
+
+		TVOC = (uint16_t)((raw_results[2] << 8) | raw_results[3]);
+		return OK;
+	}
+
+	return WRONG_MODE_WARNING;
+}
+
+int8_t driver::sensors::ccs811::co2::get_raw_data(std::shared_ptr<struct ccs811_raw_data>& raw)
+{
+	if (check_device_mode() == OK)
+	{
+		std::shared_ptr<struct ccs811_result_data> results = std::make_shared<struct ccs811_result_data>();
+		if (get_all_result_data(results) != OK)
+		{
+			std::cerr << "CCS881 [get_raw_data] Error: Could not read raw data from the device." << std::endl;
+			return COMMUNICATION_FAIL;
+		}
+
+		raw = std::make_shared<struct ccs811_raw_data>(results->raw_data);
+		return OK;
+	}
+
+	return WRONG_MODE_WARNING;
+}
+
+int8_t driver::sensors::ccs811::co2::get_all_result_data(std::shared_ptr<struct ccs811_result_data>& result)
+{
+	if (check_device_mode() == OK)
+	{
+		uint8_t raw_results[8] = { 0, 0, 0, 0, 0, 0, 0, 0 };
+		if (m_use_power_safe_mode) wake_device();
+		int8_t i2c_res = m_read_function(m_file_handle, RESULT_DATA_REG, raw_results, RAW_DATA_LEN);
+		if (m_use_power_safe_mode) unwake_device();
+		if (i2c_res != OK)
+		{
+			std::cerr << "CCS881 [get_all_result_data] Error: Could not read all result data from the device." << std::endl;
+			return COMMUNICATION_FAIL;
+		}
+
+		result->eco2_value = (uint16_t)((raw_results[0] << 8) | raw_results[1]);
+		result->tvoc_value = (uint16_t)((raw_results[2] << 8) | raw_results[3]);
+		result->status = raw_results[4];
+		result->error_id = raw_results[5];
+		result->raw_data.current = value_of_bits(raw_results[6], 2, 7);
+		result->raw_data.voltage = (uint16_t)(value_of_bits(raw_results[6], 0, 1) << 8 | (raw_results[7]));
+
+		return OK;
+	}
+
+	return WRONG_MODE_WARNING;
+}
+
+int8_t driver::sensors::ccs811::co2::set_environment_data(uint16_t temperature, uint16_t humidity)
+{
+	if (check_device_mode() == OK)
+	{
+		// Rounds humidity and temperature in 0.5 steps:
+		// 35.1 -> 35.0
+		// 35.3 -> 35.5
+		// 35.7 -> 35.5
+		// 35.8 -> 36.0
+		uint8_t environment_data[4] = { 0, 0, 0, 0 };
+		uint8_t hum_fraction = (uint8_t)((uint8_t)(humidity % 100) / (uint8_t)10);
+		environment_data[0] = (hum_fraction > 7) ? (uint8_t)((humidity / (uint8_t)(100 + 1)) << 1) : (uint8_t)((uint8_t)(humidity / 100) << 1); // Rounds integral part up if fraction is greater 0.7
+		if (hum_fraction > 2 && hum_fraction < 8)
+		{
+			environment_data[1] = 1; // Sets fractional part to 0.5 if it is in the range [0.2, 0.7]
+		}
+
+		temperature = (uint16_t)(temperature + (uint16_t)2500); // The sensor needs an offset of 25°C (2500 = 25 * 100) to be applied to the actual temperature.
+		uint8_t temp_fraction = (uint8_t)((temperature % 100) / (uint8_t)10);
+		environment_data[2] = (temp_fraction > 7) ? (uint8_t)((temperature / (uint8_t)(100 + 1)) << 1) : (uint8_t)((uint8_t)(temperature / 100) << 1); // Rounds integral part up if fraction is greater 0.7
+		if (temp_fraction > 2 && temp_fraction < 8)
+		{
+			environment_data[3] = 1; // Sets fractional part to 0.5 if it is in the range [0.2, 0.7]
+		}
+
+		if (m_use_power_safe_mode) wake_device();
+		int8_t i2c_res = m_write_function(m_file_handle, ENV_DATA_REG, environment_data, ENV_HUM_DATA_LEN + ENV_TEMP_DATA_LEN);
+		if (m_use_power_safe_mode) unwake_device();
+		if (i2c_res != OK)
+		{
+			std::cerr << "CCS881 [set_environment_data] Error: Could not write environment data to the device." << std::endl;
+			return COMMUNICATION_FAIL;
+		}
+
+		return OK;
+	}
+
+	return WRONG_MODE_WARNING;
+}
+
+int8_t driver::sensors::ccs811::co2::get_NTC_data(std::shared_ptr<struct ccs811_ntc>& ntc)
+{
+	if (check_device_mode() == OK)
+	{
+		uint8_t ntc_results[4] = { 0, 0, 0, 0 };
+		if (m_use_power_safe_mode) wake_device();
+		int8_t i2c_res = m_read_function(m_file_handle, NTC_REG, ntc_results, NTC_LEN);
+		if (m_use_power_safe_mode) unwake_device();
+		if (i2c_res != OK)
+		{
+			std::cerr << "CCS881 [get_NTC_data] Error: Could not read NTC data from the device." << std::endl;
+			return COMMUNICATION_FAIL;
+		}
+
+		ntc->v_over_resistor = (uint16_t)((ntc_results[0] << 8) | ntc_results[1]);
+		ntc->v_over_ntc = (uint16_t)((ntc_results[2] << 8) | ntc_results[3]);
+
+		return OK;
+	}
+
+	return WRONG_MODE_WARNING;
+}
+
+int8_t driver::sensors::ccs811::co2::set_thresholds(std::shared_ptr<struct ccs811_thresholds> thresholds)
+{
+	if (check_device_mode() == OK)
+	{
+		uint8_t* data = (uint8_t*)&thresholds->low_medium_threshold;
+		if (m_use_power_safe_mode) wake_device();
+		int8_t i2c_res = m_write_function(m_file_handle, THRESHOLDS_REG, data, THRESHOLDS_LOW_MEDIUM_LEN + THRESHOLDS_MEDIUM_HIGH_LEN + THRESHOLDS_HYSTERESIS_LEN);
+		if (m_use_power_safe_mode) unwake_device();
+		if (i2c_res != OK)
+		{
+			std::cerr << "CCS881 [set_thresholds] Error: Could not write thresholds to the device." << std::endl;
+			return COMMUNICATION_FAIL;
+		}
+		return OK;
+	}
+	return WRONG_MODE_WARNING;
+}
+
+int8_t driver::sensors::ccs811::co2::get_current_baseline(uint8_t baseline[BASELINE_LEN])
+{
+	if (check_device_mode() == OK)
+	{
+		if (m_use_power_safe_mode) wake_device();
+		int8_t i2c_res = m_read_function(m_file_handle, BASELINE_REG, baseline, BASELINE_LEN);
+		if (m_use_power_safe_mode) unwake_device();
+		if (i2c_res != OK)
+		{
+			std::cerr << "CCS881 [get_current_baseline] Error: Could not read baseline data from the device." << std::endl;
+			return COMMUNICATION_FAIL;
+		}
+		return OK;
+	}
+	return WRONG_MODE_WARNING;
+}
+
+int8_t driver::sensors::ccs811::co2::set_baseline(uint8_t baseline[BASELINE_LEN])
+{
+	if (check_device_mode() == OK)
+	{
+		if (m_use_power_safe_mode) wake_device();
+		int8_t i2c_res = m_write_function(m_file_handle, BASELINE_REG, baseline, BASELINE_LEN);
+		if (m_use_power_safe_mode) unwake_device();
+		if (i2c_res != OK)
+		{
+			std::cerr << "CCS881 [set_baseline] Error: Could not write baseline data to the device." << std::endl;
+			return COMMUNICATION_FAIL;
+		}
+		return OK;
+	}
+	return WRONG_MODE_WARNING;
+}
+
+int8_t driver::sensors::ccs811::co2::delete_current_firmware()
+{
+	if (check_device_mode() == 1) // Device is in BOOT mode
+	{
+		// ToDo: Implement
+		return OK;
+	}
+	return WRONG_MODE_WARNING;
+}
+
+int8_t driver::sensors::ccs811::co2::write_new_firmware(std::shared_ptr<uint8_t[]> new_firmware, uint16_t byte_count)
+{
+	if (check_device_mode() == 1) // Device is in BOOT mode
+	{
+		// ToDo: Implement
+		return OK;
+	}
+	return WRONG_MODE_WARNING;
+}
+
+int8_t driver::sensors::ccs811::co2::verify_firmware(bool& firmware_valid)
+{
+	if (check_device_mode() == 1) // Device is in BOOT mode
+	{
+		// ToDo: Implement
+		return OK;
+	}
+	return WRONG_MODE_WARNING;
+}
+
+int8_t driver::sensors::ccs811::co2::check_device_mode()
+{
+	std::shared_ptr<struct ccs811_status> status = std::make_shared<struct ccs811_status>();
+	if (get_status_information(status) != OK)
+	{
+		std::cerr << "CCS881 [check_device_mode] Error: Could not read status information from the device." << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	if (status->current_state == ccs811_state::BOOT)
+	{
+		return 1;
+	}
+
+	return OK;
+}
+
+int8_t driver::sensors::ccs811::co2::read_error(uint8_t& error_code)
+{
+	if (m_use_power_safe_mode) wake_device();
+	int8_t i2c_res = m_read_function(m_file_handle, ERROR_REG, &error_code, ERROR_LEN);
+	if (m_use_power_safe_mode) unwake_device();
+	if (i2c_res != OK)
+	{
+		std::cerr << "CCS881 [read_error] Error: Could not read error data from the device." << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+	return OK;
+}
+
+void driver::sensors::ccs811::co2::wake_device()
+{
+	digitalWrite(m_wake_gpio_pin, LOW);
+	usleep(AWAKE_TIME_IN_US);
+}
+
+void driver::sensors::ccs811::co2::unwake_device()
+{
+	digitalWrite(m_wake_gpio_pin, HIGH);
+	usleep(DWAKE_TIME_IN_US);
+}
+
+void driver::sensors::ccs811::co2::start_interrupt_thread()
+{
+	if (m_interrupt_thread == nullptr)
+	{
+		m_use_interrupt_mode = true;
+		m_interrupt_thread = new std::thread(&driver::sensors::ccs811::co2::interrupt_mode_loop, this);
+	}
+}
+
+void driver::sensors::ccs811::co2::stop_interrupt_thread()
+{
+	if (m_interrupt_thread != nullptr)
+	{
+		m_use_interrupt_mode = false;
+		m_interrupt_thread->join();
+	}
+}
+
+void driver::sensors::ccs811::co2::wait_for_data_flag()
+{
+	bool data_available = false;
+	while (!data_available && m_use_interrupt_mode)
+	{
+		mode_dependent_sleep();
+		if (digitalRead(m_int_gpio_pin_nr) == LOW)
+		{
+			data_available = true;
+		}
+	}
+}
+
+void driver::sensors::ccs811::co2::interrupt_mode_loop()
+{
+	while (m_use_interrupt_mode)
+	{
+		if (m_int_check_thread == nullptr)
+		{
+			m_int_check_thread = new std::thread(&driver::sensors::ccs811::co2::wait_for_data_flag, this);
+		}
+		m_int_check_thread->join();
+		m_int_check_thread = nullptr;
+
+
+		// Read data
+		std::shared_ptr<struct ccs811_result_data>results = std::make_shared<struct ccs811_result_data>();
+		if (get_all_result_data(results) != OK)
+		{
+			std::cerr << "CCS881 [interrupt_mode_loop] Error: Could not read result data from the device." << std::endl;
+			return;
+		}
+
+		// Execute callback with new values
+		m_data_callback(results->eco2_value, results->tvoc_value);
+	}
+}
+
+void driver::sensors::ccs811::co2::mode_dependent_sleep()
+{
+	switch (m_current_mode)
+	{
+	case ccs811_operation_mode::PULSE_10_S:
+		sleep(10);
+		return;
+	case ccs811_operation_mode::PULSE_60_S:
+		sleep(60);
+		return;
+	case ccs811_operation_mode::CONSTANT_POWER_1_S:
+		sleep(1);
+		return;
+	case ccs811_operation_mode::CONSTANT_POWER_250_MS:
+		usleep(250000);
+		return;
+	case ccs811_operation_mode::SLEEP:
+	default:
+		return;
+	}
+}
+
+int8_t driver::sensors::ccs811::co2::soft_reset()
+{
+	// No need to implement this method for this sensor
+	return int8_t();
+}
+
+int8_t driver::sensors::ccs811::co2::get_all_raw_data(uint8_t* all_data)
+{
+	// No need to implement this method for this sensor
+	return int8_t();
+}

--- a/PiDashboardBackend/src/drivers/ccs811_co2.h
+++ b/PiDashboardBackend/src/drivers/ccs811_co2.h
@@ -1,0 +1,385 @@
+#pragma once
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <wiringPi.h>
+#include <thread>
+#include <vector>
+
+#include "sensor_base.h"
+#include "ccs811_co2_constants.h"
+#include "ccs811_co2_definitions.h"
+#include "../manager/i2c_manager.h"
+
+namespace driver
+{
+	namespace sensors
+	{
+		namespace ccs811
+		{
+			//! Class that communicates with the CCS811 sensor (AMS) via I2C.
+			/*!
+			* This class implements various functions to configure the sensor and receive the measured data.
+			*/
+			class co2 : sensor_base
+			{
+			protected:
+				//! Opens a device connection and performs basic setup.
+				/*!
+				* Tries to open the device at the given i2c address in O_RDWR and I2C_SLAVE mode.
+				* It also reads and stores the device id and the calibration constants.
+				* \param[in] device_reg: The address of the device to open.
+				* \param[in] read_function: Function pointer to the function that does i2c read operations.
+				* \param[in] write_function: Function pointer to the function that does i2c write operations.
+				* \param[in] open_device_function: Function pointer to the function that opens an i2c connection.
+				* \param[in] close_device_function: Function pointer to the function that closes an i2c connection.
+				* \returns 0 if initializing the device was successful, a negative error value otherwise.
+				*/
+				int8_t init(uint8_t device_reg = SENSOR_PRIMARY_I2C_REG,
+					std::function<int8_t(int, uint8_t, uint8_t*, uint16_t)> read_function = manager::i2c_manager::read_from_device,
+					std::function<int8_t(int, uint8_t, const uint8_t*, uint16_t)> write_function = manager::i2c_manager::write_to_device,
+					std::function<int8_t(const std::string, uint8_t, int&)> open_device_function = manager::i2c_manager::open_device,
+					std::function<int8_t(int&)> close_device_function = manager::i2c_manager::close_device);
+
+			public:
+				//! Default constructor.
+				/*!
+				* Default constructor.
+				*/
+				co2() {}
+
+				//! Default destructor.
+				/*!
+				* Default destructor.
+				*/
+				~co2() {  }
+
+
+				//! Opens a device connection and performs basic setup.
+				/*!
+				* Tries to open the device at the given i2c address in O_RDWR and I2C_SLAVE mode.
+				* It also reads and stores the device id and the calibration constants.
+				* \param[in] use_power_safe_mode: Whether the devices processor should be put to sleep mode between i2c requests or not.
+				* \param[in] wake_gpio_pin_nr: The GPIO pin number of the nWAKE pin that is used to put the device to sleep and wake it up.
+				* \param[in] int_gpio_pin_nr: The GPIO pin number of the INT pin that is used to notify if new data is available.
+				* \param[in] data_callback: A callback function that gets called if the device is operated in Interrupt mode and new
+				* data gets available. It gets called with the new measured eCO2 and TVOC values as parameters.
+				* \param[in] device_reg: The address of the device to open.
+				* \param[in] read_function: Function pointer to the function that does i2c read operations.
+				* \param[in] write_function: Function pointer to the function that does i2c write operations.
+				* \param[in] open_device_function: Function pointer to the function that opens an i2c connection.
+				* \param[in] close_device_function: Function pointer to the function that closes an i2c connection.
+				* \returns 0 if initializing the device was successful, a negative error value otherwise.
+				*/
+				int8_t init(bool use_power_safe_mode, int wake_gpio_pin_nr, int int_gpio_pin_nr,
+					std::function<void(uint16_t, uint16_t)> data_callback,
+					uint8_t device_reg = SENSOR_PRIMARY_I2C_REG,
+					std::function<int8_t(int, uint8_t, uint8_t*, uint16_t)> read_function = manager::i2c_manager::read_from_device,
+					std::function<int8_t(int, uint8_t, const uint8_t*, uint16_t)> write_function = manager::i2c_manager::write_to_device,
+					std::function<int8_t(const std::string, uint8_t, int&)> open_device_function = manager::i2c_manager::open_device,
+					std::function<int8_t(int&)> close_device_function = manager::i2c_manager::close_device);
+
+				//! Closes a device connection and performs some cleanup.
+				/*!
+				*  Closes a device connection and performs some cleanup.
+				* \returns 0 if closing the device was successful, a negative error value otherwise.
+				*/
+				int8_t close();
+
+				//! Activates or deactivates the power safe mode.
+				/*!
+				*  Activates or deactivates the power safe mode.
+				* \param[in] use_power_safe_mode: True to activate the power safe mode, false to deactivate it.
+				* \returns 0 if toggling the power safe mode was successful, a negative error value otherwise.
+				*/
+				int8_t toggle_power_safe_mode(bool use_power_safe_mode);
+
+				//! Changes the device state from BOOT to READY.
+				/*!
+				* Changes the device state from BOOT to READY. This tries to load the firmware and start the
+				* device application. After the device entered READY state it can be used to receive measurements.
+				* The sensor might need some time to deliver trustful sensor values. On average this warm up phase
+				* takes about 20 minutes.
+				* \returns 0 if starting the device was successful, a negative error value otherwise.
+				*/
+				int8_t start();
+
+				//! Returns the status information of this device.
+				/*!
+				*  Returns the status information of this device.
+				* \param[out] status: The status information of the device.
+				* \returns 0 if getting the device status was successful, a negative error value otherwise.
+				*/
+				int8_t get_status_information(std::shared_ptr<struct ccs811_status>& status);
+
+				//! Returns information about this device.
+				/*!
+				*  Returns information about this device. Included are device id, hardware id, hardware version,
+				*  firmware version and application version.
+				* \param[out] info: The information about the device.
+				* \returns 0 if getting the device information was successful, a negative error value otherwise.
+				*/
+				int8_t get_device_information(std::shared_ptr<struct ccs811_device_info>& info);
+
+				//! Returns the operation mode information of this device.
+				/*!
+				*  Returns the operation mode information of this device.
+				* \param[out] mode: The operation mode information of the device.
+				* \returns 0 if getting the device operation mode was successful, a negative error value otherwise.
+				*/
+				int8_t get_operation_mode_information(std::shared_ptr<struct ccs811_mode_info>& mode);
+
+				//! Sets the operation mode of this device.
+				/*!
+				*  Sets the operation mode of this device.
+				* \param[in] mode: The new operation mode of the device.
+				* \param[in] interrupt_mode: True if interrupt mode should be used.
+				* \param[in] use_thresholds: True if thresholds should be used.
+				* \returns 0 if setting the device mode was successful, a negative error value otherwise.
+				*/
+				int8_t set_operation_mode(enum ccs811_operation_mode mode, bool interrupt_mode, bool use_thresholds);
+
+				//! Returns the current eCO2 value.
+				/*!
+				* Returns the current eCO2 value.
+				* \param[out] eCO2: The measured eCO2 value.
+				* \returns 0 if measuring the eCO2 was successful, a negative error value otherwise.
+				*/
+				int8_t get_eCO2_data(uint16_t& eCO2);
+
+				//! Returns the current TVOC value.
+				/*!
+				* Returns the current TVOC value.
+				* \param[out] TVOC: The measured TVOC value.
+				* \returns 0 if measuring the TVOC was successful, a negative error value otherwise.
+				*/
+				int8_t get_TVOC_data(uint16_t& TVOC);
+
+				//! Returns the current raw data (current and voltage).
+				/*!
+				* Returns the current raw data (current and voltage).
+				* \param[out] raw: The current raw values.
+				* \returns 0 if getting the raw data was successful, a negative error value otherwise.
+				*/
+				int8_t get_raw_data(std::shared_ptr<struct ccs811_raw_data>& raw);
+
+				//! Returns all data at the result register address.
+				/*!
+				* Returns all data at the result register address. The data consists of eCO2 and TVOC values
+				* a status, an error id and the raw data.
+				* \param[out] result: The current result data.
+				* \returns 0 if getting the result data was successful, a negative error value otherwise.
+				*/
+				int8_t get_all_result_data(std::shared_ptr<struct ccs811_result_data>& result);
+
+				//! Sets the current temperature and humidity.
+				/*!
+				* Sets the current temperature and humidity in order to improve the calculation of
+				* the eCO2 and TVOC values.
+				* \param[in] temperature: The current temperature in degree celsius. The value is assumed to
+				* be 2 orders of magnitude greater than the usual value (e.g. 25.3°C will be 2530). At the
+				* moment the CCS811 only supports 0.5 and 0 as fractions. Therefore all values will be rounded.
+				* \param[in] humidity: The current humidity in percent. The value is assumed to be 2 orders of
+				* magnitude greater than the usual value (e.g. 37.45% will be 3745). At the moment the CCS811
+				* only supports 0.5 and 0 as fractions. Therefore all values will be rounded.
+				* \returns 0 if setting the environment data was successful, a negative error value otherwise.
+				*/
+				int8_t set_environment_data(uint16_t temperature, uint16_t humidity);
+
+				//! Returns the current voltage over the resistor and the NTC resistor.
+				/*!
+				* Returns the current voltage over the resistor and the NTC resistor. Can be used to calculate
+				* the current temperature.
+				* \param[out] ntc: The current voltages over resistor and NTC.
+				* \returns 0 if getting the NTC data was successful, a negative error value otherwise.
+				*/
+				int8_t get_NTC_data(std::shared_ptr<struct ccs811_ntc>& ntc);
+
+				//! Sets thresholds to control whether a new eCO2 is treated as new value.
+				/*!
+				* Only if a eCO2 measurement exceeds a threshold it is treated as a new value and can be
+				* read by the host. "interrupt on threshold change" has to be activated in mode register.
+				* \param[in] thresholds: The new thresholds to set. Low and High thresholds may have the
+				* same value if only one threshold is needed.
+				* \returns 0 if setting the thresholds was successful, a negative error value otherwise.
+				*/
+				int8_t set_thresholds(std::shared_ptr<struct ccs811_thresholds> thresholds);
+
+				//! Returns the current baseline.
+				/*!
+				* Returns the current baseline that is used to normalize the measured values. Since
+				* temperature, humidity or other environmental conditions change over time, the baseline
+				* has to be recalculated continuously. The sensor does this automatically and thus improves
+				* the baseline more and more. However to compensate outer condition changes the baseline
+				* should be saved on the host from time to time. This way you can correct the baseline if
+				* outliers distored it.
+				* The frequency to store baselines depends on the operation mode. If the sensor runs 24/7,
+				* the host should save baselines every 24h-48h during the first 500h (~21 days) of operation
+				* time. Afterwards the frequency can be lowered to one baseline each 5-7 days.
+				* If the sensor only runs sporadic the host should try to save a baseline at least before
+				* a power off. The host also should save a serparate baseline for each operation mode to
+				* reduce measurement errors.
+				*
+				* \param[out] baseline: The current baseline values.
+				* \returns 0 if getting the baseline was successful, a negative error value otherwise.
+				*/
+				int8_t get_current_baseline(uint8_t baseline[BASELINE_LEN]);
+
+				//! Sets the current baseline.
+				/*!
+				* Sets a previously stored baseline. The baseline should have been saved during clean air
+				* conditions in order to not distort the sensors measure results.
+				*
+				* \param[in] baseline: The baseline values to set.
+				* \returns 0 if setting the baseline was successful, a negative error value otherwise.
+				*/
+				int8_t set_baseline(uint8_t baseline[BASELINE_LEN]);
+
+				//! WARNING: Deletes the firmware of the device.
+				/*!
+				* This operation might take some time and can only be performed in BOOT state. Read the status
+				* register to check if the operation has finished.
+				*
+				* WARNING: Deletes the firmware of the device. The device can not be used anymore to measure
+				*          eCO2 and TVOC values after deleting the firmware.
+				*          You have to copy a new firmware to the device in order to restore its functionality.
+				* WARNING: This class does not store any fallback firmware version in case you deleted the one
+				*          on the sensor!
+				* \returns 0 if deleting the firmware was successful, a negative error value otherwise.
+				*/
+				int8_t delete_current_firmware();
+
+				//! Writes new a firmware version to the device.
+				/*!
+				* This operation might take some time and can only be performed in BOOT state. Read the status
+				* register to check if the operation has finished.
+				*
+				* WARNING: There will be no backup of the old firmware version.
+				* WARNING: Please delete the old firmware by calling "delete_current_firmware()" first.
+				* WARNING: The device might not work as expected after changing the firmware version.
+				*
+				* \param[in] new_firmware: The new firmware to write to the device.
+				* \param[in] byte_count: The size of the new firmware. Since only 9 bytes can be written at once
+				* this value is used to cut the firmware in 9-byte parts.
+				* \returns 0 if writing the new firmware to the device was successful, a negative error value otherwise.
+				*/
+				int8_t write_new_firmware(std::shared_ptr<uint8_t[]> new_firmware, uint16_t byte_count);
+
+				//! Verifies the currently installed firmware.
+				/*!
+				* Verifies the currently installed firmware. This only has to be done after installing
+				* a new firmware since the result will be stored directly on the device. The verification
+				* can only be done in BOOT state and might take some time to complete. Read the status
+				* register to check if the operation has finished.
+				*
+				* \param[out] firmware_valid: True if the firmware is valid, false otherwise.
+				* \returns 0 if verifying the firmware was successful, a negative error value otherwise.
+				*/
+				int8_t verify_firmware(bool& firmware_valid);
+
+				//! Performs a soft reset on the device.
+				/*!
+				* Performs a soft reset on the device.
+				* \returns 0 if resetting the device was successful, a negative error value otherwise.
+				*/
+				virtual int8_t soft_reset() override;
+
+			private:
+				//! Checks whether the device is currently in BOOT or normal operation mode.
+				/*!
+				* Checks whether the device is currently in BOOT or normal operation mode.
+
+				* \returns 0 for normal operation mode, 1 for BOOT mode and a negative error value otherwise.
+				*/
+				int8_t check_device_mode();
+
+				//! Tries to read an error code from the device register.
+				/*!
+				* Tries to read an error code from the device register.
+				* \param[out] error_code: The error code that was read from the device.
+				* \returns 0 if reading the error code was successful, a negative error value otherwise.
+				*/
+				int8_t read_error(uint8_t& error_code);
+
+				//! Simply reads all content from the device at once.
+				/*!
+				*  Simply reads all content from the device at once. The function should only be used for
+				*  debug purposes.
+				* \param[out] all_data: A buffer to store the content.
+				* \returns 0 if reading all data was successful, a negative error value otherwise.
+				*/
+				virtual int8_t get_all_raw_data(uint8_t* all_data) override;
+
+				//! Sets the nWAKE pin to low which wakes the device processor up.
+				/*!
+				* Sets the nWAKE pin to low which wakes the device processor up. By waking the
+				* device before every i2c request its power consumption can be drastically reduced
+				* compared to the nWAKE pin being always low.
+				*/
+				void wake_device();
+
+				//! Sets the nWAKE pin to high which puts the device processor to sleep mode.
+				/*!
+				* Sets the nWAKE pin to high which puts the device processor to sleep mode. By
+				* setting the device to sleep mode after every i2c request its power consumption
+				* can be drastically reduced compared to the nWAKE pin being always low.
+				*/
+				void unwake_device();
+
+				//! Starts a new thread that executes the <wait_for_data_flag>"() method.
+				/*!
+				* Starts a new thread that executes the <wait_for_data_flag>"() method.
+				* Measure mode has to be set to interrupt to activate this kind of notification
+				* and data access.
+				*/
+				void start_interrupt_thread();
+
+				//! Stops the interrupt mode thread if it is running.
+				/*!
+				* Stops the interrupt mode thread if it is running.
+				*/
+				void stop_interrupt_thread();
+
+				//! Funktion that continuously checks the state of the nINT gpio pin.
+				/*!
+				* Funktion that continuously checks the state of the nINT gpio pin. If the pin goes
+				* LOW it means that new data is available on the sensor. As a result <new_data_ready>"()"
+				* will be called and this method finishes. This method should be executed inside a thread.
+				* Measure mode has to be set to interrupt to activate this kind of notification and data
+				* access.
+				*/
+				void wait_for_data_flag();
+
+				//! Thread function that controls the inner interupt check thread.
+				/*!
+				* The function checks if the int check thread finished. If this is the case, it reads
+				* data from the sensor and restarts the thread.
+				*/
+				void interrupt_mode_loop();
+
+				//! Puts the calling thread to sleep mode by calling sleep().
+				/*!
+				* Puts the calling thread to sleep mode by calling sleep(). The sleep time depends on the
+				* current operation mode:
+				* - SLEEP -> 0 seconds
+				* - PULSE_60_S -> 60 seconds
+				* - PULSE_10_S -> 10 seconds
+				* - CONSTANT_POWER_1_S -> 1 second
+				* - CONSTANT_POWER_250_MS -> 0.25 seconds
+				*/
+				void mode_dependent_sleep();
+
+				bool m_use_power_safe_mode;
+				bool m_use_interrupt_mode;
+				int m_wake_gpio_pin;
+				int m_int_gpio_pin_nr;
+				std::thread* m_interrupt_thread;
+				std::thread* m_int_check_thread;
+				std::function<void(uint16_t, uint16_t)> m_data_callback;
+				enum ccs811_operation_mode m_current_mode;
+			};
+		}
+	}
+}
+

--- a/PiDashboardBackend/src/drivers/ccs811_co2_constants.h
+++ b/PiDashboardBackend/src/drivers/ccs811_co2_constants.h
@@ -1,0 +1,115 @@
+#pragma once
+#include <cstdint>
+
+namespace driver
+{
+	namespace sensors
+	{
+		namespace ccs811
+		{
+			static constexpr const uint8_t HARDWARE_ID_VALUE = 0X81;
+			static constexpr const uint8_t SENSOR_PRIMARY_I2C_REG = 0X5A;
+			static constexpr const uint8_t SENSOR_SECONDARY_I2C_REG = 0X5B;
+
+			// Operation mode addresses
+			static constexpr const uint8_t STATUS_REG = 0X00;
+			static constexpr const uint8_t MODE_REG = 0X01;
+			static constexpr const uint8_t RESULT_DATA_REG = 0X02;
+			static constexpr const uint8_t ENV_DATA_REG = 0X05;
+			static constexpr const uint8_t NTC_REG = 0X06;
+			static constexpr const uint8_t THRESHOLDS_REG = 0X10;
+			static constexpr const uint8_t BASELINE_REG = 0X11;
+			static constexpr const uint8_t HARDWARE_ID_REG = 0X20;
+			static constexpr const uint8_t HARDWARE_VERSION_REG = 0X21;
+			static constexpr const uint8_t FIRMWARE_VERSION_REG = 0X23;
+			static constexpr const uint8_t APPLICATION_VERSION_REG = 0X24;
+			static constexpr const uint8_t ERROR_REG = 0XE0;
+			static constexpr const uint8_t RESET_REG = 0XFF;
+
+			// Operation mode lengths
+			static constexpr const uint8_t STATUS_LEN = 1;
+			static constexpr const uint8_t MODE_LEN = 1;
+			static constexpr const uint8_t ECO2_LEN = 2;
+			static constexpr const uint8_t TVOC_LEN = 4;
+			static constexpr const uint8_t RESULT_DATA_STATUS_LEN = 5;
+			static constexpr const uint8_t RESULT_DATA_ERROR_LEN = 6;
+			static constexpr const uint8_t RAW_DATA_LEN = 8;
+			static constexpr const uint8_t ENV_TEMP_DATA_LEN = 2;
+			static constexpr const uint8_t ENV_HUM_DATA_LEN = 2;
+			static constexpr const uint8_t NTC_LEN = 2;
+			static constexpr const uint8_t THRESHOLDS_LOW_MEDIUM_LEN = 2;
+			static constexpr const uint8_t THRESHOLDS_MEDIUM_HIGH_LEN = 2;
+			static constexpr const uint8_t THRESHOLDS_HYSTERESIS_LEN = 1;
+			static constexpr const uint8_t BASELINE_LEN = 2;
+			static constexpr const uint8_t HARDWARE_ID_LEN = 1;
+			static constexpr const uint8_t HARDWARE_VERSION_LEN = 1;
+			static constexpr const uint8_t FIRMWARE_VERSION_LEN = 2;
+			static constexpr const uint8_t APPLICATION_VERSION_LEN = 2;
+			static constexpr const uint8_t ERROR_LEN = 1;
+			static constexpr const uint8_t RESET_LEN = 1;
+
+			// Boot mode addresses
+			static constexpr const uint8_t STATUS_BOOT_REG = 0X00;
+			static constexpr const uint8_t APP_ERASE_BOOT_REG = 0XF1;
+			static constexpr const uint8_t APP_DATA_BOOT_REG = 0XF2;
+			static constexpr const uint8_t APP_VERIFY_BOOT_REG = 0XF3;
+			static constexpr const uint8_t APP_START_BOOT_REG = 0XF4;
+
+			// Boot mode lengths
+			static constexpr const uint8_t STATUS_BOOT_LEN = 1;
+			static constexpr const uint8_t APP_ERASE_BOOT_LEN = 4;
+			static constexpr const uint8_t APP_DATA_BOOT_LEN = 9;
+			static constexpr const uint8_t APP_VERIFY_BOOT_LEN = 1;
+			static constexpr const uint8_t APP_START_LEN = 1;
+
+			// Reset Codes
+			static constexpr const uint8_t RESET_1 = 0X11;
+			static constexpr const uint8_t RESET_2 = 0XE5;
+			static constexpr const uint8_t RESET_3 = 0X72;
+			static constexpr const uint8_t RESET_4 = 0X8A;
+			static constexpr const uint8_t ERASE_1 = 0XE7;
+			static constexpr const uint8_t ERASE_2 = 0XA7;
+			static constexpr const uint8_t ERASE_3 = 0XE6;
+			static constexpr const uint8_t ERASE_4 = 0X09;
+
+			// Modes
+			static constexpr const uint8_t SLEEP = 0 << 4;
+			static constexpr const uint8_t CONSTANT_POWER_1_S = 1 << 4;
+			static constexpr const uint8_t PULSE_10_S = 2 << 4;
+			static constexpr const uint8_t PULSE_60_S = 3 << 4;
+			static constexpr const uint8_t CONSTANT_POWER_250_MS = 4 << 4;
+			static constexpr const uint8_t MODE_MASK = 0x70;
+
+			// Extremas
+			static constexpr const uint16_t LOW_MEDIUM_DEFAULT_THRES = 1500;
+			static constexpr const uint16_t MEDIUM_HIGH_DEFAULT_THRES = 2500;
+			static constexpr const uint8_t HYSTERESIS_DEFAULT_THRES = 50;
+			static constexpr const uint16_t ECO2_MAX = 8192;
+			static constexpr const uint16_t ECO2_MIN = 400;
+			static constexpr const uint16_t TVOC_MAX = 1187;
+			static constexpr const uint16_t TVOC_MIN = 0;
+			static constexpr const uint8_t TEMPERATURE_BASELINE = 25;
+
+			// Time constants
+			static constexpr const uint32_t NEW_SENSOR_BURN_IN_TIME_IN_S = 172800; // 48h in seconds (for new sensors only)
+			static constexpr const uint32_t SENSOR_WARM_UP_TIME_IN_S = 1200; // 20min in seconds (after changing to higher sampling mode)
+			static constexpr const uint32_t BASELINE_THRESHOLD_IN_S = 1800000; // 500h in seconds (in 24/7 usage. First 500h save Baseline every 24h-48h, afterwards save it all 5-7 days)
+			static constexpr const uint32_t BASELINE_EARLY_SAVE_TIME_IN_S = 129600; // 36h in seconds (in 24/7 usage. First 500h save Baseline every 24h-48h)
+			static constexpr const uint32_t BASELINE_LATE_SAVE_TIME_IN_S = 518400; // 144h (6d) in seconds (in 24/7 usage. After 500h save Baseline every 5-7 days)
+			static constexpr const uint32_t AWAKE_TIME_IN_US = 75; // 75 micro seconds. Datasheet says it takes minimum 50 micro seconds to awake the processor, so I decided to give him a little bit more time
+			static constexpr const uint32_t DWAKE_TIME_IN_US = 45; // 35 micro seconds. Datasheet says the minimum time to deassert awake is 20 micro seconds to, so I decided to give it a little bit more time
+
+			// Warnings
+			static constexpr const int8_t MODE_SWITCH_WARNING = 34;
+			static constexpr const int8_t WRONG_MODE_WARNING = 35;
+
+			// Error codes
+			static constexpr const int8_t WRITE_REG_INVALID = 1;
+			static constexpr const int8_t READ_REG_INVALID = 1 << 1;
+			static constexpr const int8_t MEASUREMODE_INVALID = 1 << 2;
+			static constexpr const int8_t MAX_RESISTANCE = 1 << 3;
+			static constexpr const int8_t HEATER_FAULT = 1 << 4;
+			static constexpr const int8_t HEATER_SUPPLY_ERROR = 1 << 5;
+		}
+	}
+}

--- a/PiDashboardBackend/src/drivers/ccs811_co2_definitions.h
+++ b/PiDashboardBackend/src/drivers/ccs811_co2_definitions.h
@@ -1,0 +1,80 @@
+#pragma once
+
+namespace driver
+{
+	namespace sensors
+	{
+		namespace ccs811
+		{
+			enum class ccs811_operation_mode : uint8_t
+			{
+				SLEEP = 0,
+				PULSE_60_S = 1,
+				PULSE_10_S = 2,
+				CONSTANT_POWER_1_S = 3,
+				CONSTANT_POWER_250_MS = 4
+			};
+
+			enum class ccs811_state : uint8_t
+			{
+				BOOT = 0,
+				READY = 1,
+			};
+
+			struct ccs811_device_info
+			{
+				uint8_t device_id;
+				uint8_t hardware_id;
+				std::string hardware_version;
+				std::string firmware_version;
+				std::string application_version;
+			};
+
+			struct ccs811_thresholds
+			{
+				uint16_t low_medium_threshold;
+				uint16_t medium_high_threshold;
+				uint8_t hysteresis_threshold;
+			};
+
+			struct ccs811_ntc
+			{
+				uint16_t v_over_resistor;
+				uint16_t v_over_ntc;
+			};
+
+			struct ccs811_status
+			{
+				uint8_t raw_status_info;
+				ccs811_state current_state;
+				bool firmware_loaded;
+				bool data_ready;
+				bool has_error;
+				std::vector<std::string> error_message;
+			};
+
+			struct ccs811_mode_info
+			{
+				uint8_t raw_mode_info;
+				ccs811_operation_mode current_mode;
+				bool interrupt_gerneration;
+				bool use_threshold;
+			};
+
+			struct ccs811_raw_data
+			{
+				uint8_t current; // in micro ampere
+				uint16_t voltage; // in micro V
+			};
+
+			struct ccs811_result_data
+			{
+				uint16_t eco2_value;
+				uint16_t tvoc_value;
+				uint8_t status;
+				uint8_t error_id;
+				ccs811_raw_data raw_data;
+			};
+		}
+	}
+}

--- a/PiDashboardBackend/src/drivers/sensor_base.h
+++ b/PiDashboardBackend/src/drivers/sensor_base.h
@@ -1,0 +1,211 @@
+#pragma once
+#include <cstdint>
+#include <iostream>
+#include <functional>
+#include <memory>
+#include <bitset>
+
+namespace driver
+{
+	namespace sensors
+	{
+		static constexpr const int8_t WARNING = 0;
+		static constexpr const int8_t OK = 0;
+		static constexpr const int8_t NULL_PTR = -1;
+		static constexpr const int8_t DEVICE_NOT_FOUND = -2;
+		static constexpr const int8_t INVALID_LENGTH = -3;
+		static constexpr const int8_t COMMUNICATION_FAIL = -4;
+		static constexpr const int8_t DEVICE_ERROR = -5;
+		static constexpr const int8_t BIT_MANIPULATION_ERROR = -6;
+
+		class sensor_base
+		{
+		public:
+			//! Opens a device connection and performs basic setup.
+			/*!
+			* Tries to open the device at the given i2c address in O_RDWR and I2C_SLAVE mode.
+			* It also reads and stores the device id.
+			* \param[in] device_reg: The address of the device to open.
+			* \param[in] read_function: Function pointer to the function that does i2c read operations.
+			* \param[in] write_function: Function pointer to the function that does i2c write operations.
+			* \param[in] open_device_function: Function pointer to the function that opens an i2c connection.
+			* \param[in] close_device_function: Function pointer to the function that closes an i2c connection.
+			* \returns 0 if initializing the device was successful, a negative error value otherwise.
+			*/
+			virtual int8_t init(uint8_t device_reg,
+				std::function<int8_t(int, uint8_t, uint8_t*, uint16_t)> read_function,
+				std::function<int8_t(int, uint8_t, const uint8_t*, uint16_t)> write_function,
+				std::function<int8_t(const std::string, uint8_t, int&)> open_device_function,
+				std::function<int8_t(int&)> close_device_function) = 0;
+
+			//! Closes a device connection and performs some cleanup.
+			/*!
+			*  Closes a device connection and performs some cleanup.
+			* \returns 0 if closing the device was successful, a negative error value otherwise.
+			*/
+			virtual int8_t close() = 0;
+
+			//! Performs a soft reset on the device.
+			/*!
+			* Performs a soft reset on the device.
+			* \returns 0 if resetting the device was successful, a negative error value otherwise.
+			*/
+			virtual int8_t soft_reset() = 0;
+
+		protected:
+			//! Checks if the bit at the given position in the byte is set (1) or not (0).
+			/*!
+			*  Checks if the bit at the given position in the byte is set (1) or not (0).
+			*  The first bit is the right most number in the byte array and has the index 0.
+			* \param[in] byte: The byte value.
+			* \param[in] bit_index: The position of the bit inside the byte array.
+			* \returns True if the bit is set (1) and false if the bit is not set (0).
+			*/
+			bool is_bit_set(uint8_t byte, uint8_t bit_index)
+			{
+				if (bit_index < 0 || bit_index > 7)
+				{
+					std::cerr << "SensorBase [is_bit_set] Error: The given bit index (" << bit_index << ") is out of Bounds." << std::endl;
+					return false;
+				}
+				return (byte & (1 << bit_index)) != 0;
+			}
+
+			//! Sets the bit at the given index to the given value.
+			/*!
+			*  Sets the bit at the given index to the given value.
+			*  The first bit is the right most number in the byte array and has the index 0.
+			* \param[out] byte: The byte value.
+			* \param[in] bit_index: The position of the bit inside the byte array.
+			* \param[in] new_value: True for new value 1 and false for new value 0.
+			* \returns True if modifying the bit was successful, false otherwise.
+			*/
+			bool set_bit(uint8_t& byte, uint8_t bit_index, bool new_value)
+			{
+				if (bit_index < 0 || bit_index > 7)
+				{
+					std::cerr << "SensorBase [set_bit] Error: The given bit index (" << bit_index << ") is out of Bounds." << std::endl;
+					return false;
+				}
+				if (new_value)
+				{
+					byte |= (uint8_t)(1 << bit_index);
+				}
+				else
+				{
+					byte |= (uint8_t)(0 << bit_index);
+				}
+				return true;
+			}
+
+			//! Sets the bit at the given index to the given value.
+			/*!
+			*  Sets the bit at the given index to the given value.
+			*  The first bit is the right most number in the byte array and has the index 0.
+			* \param[out] byte: The byte value.
+			* \param[in] value: The value to place at the position the mask defines
+			* \param[in] mask: Defines the position where the new value should be placed inside the byte (1s for bits to affect, 0s for bits to ignore. 
+			*  E.g. 01110000 only changes bits 6,5,4 and tries to place the value at these bits).
+			* \returns True if modifying the bits was successful, false otherwise.
+			*/
+			bool set_bits(uint8_t& byte, uint8_t value, uint8_t mask)
+			{
+				if (count_active_bits(value) > count_active_bits(mask))
+				{
+					std::cerr << "SensorBase [set_bits] Error: The given mask has less bits set than the value. This would result in unintentional bit changes." << std::endl;
+					return false;
+				}
+				
+				// Turn off currently set bits at mask position and afterwards set the desired bits.
+				byte = (uint8_t)((byte & ~mask) | value); 
+				return true;
+			}
+
+			//! Counts the bits in a byte that are set to 1.
+			/*!
+			*  Counts the bits in a byte that are set to 1.
+			* \param[in] byte: The byte value.
+			* \returns The number of bits that are set to 1.
+			*/
+			uint8_t count_active_bits(uint8_t byte)
+			{
+				byte = (uint8_t)(byte - (uint8_t)((byte >> (uint8_t)1) & (uint8_t)0x55));
+				byte = (uint8_t)((byte & (uint8_t)0x33) + (uint8_t)((byte >> 2) & (uint8_t)0x33));
+				return ((byte + (byte >> (uint8_t)4)) & (uint8_t)0x0F) * (uint8_t)0x01;
+			}
+
+			//! Returns the value of the selected bit range from a given byte array as unsigned char.
+			/*!
+			* Returns the value of the selected bit range from a given byte array as unsigned char.
+			* Since start and end are indices, counting starts from 0 and the maximum value is 7.
+			* start_bit and end_bit are both included in the range: [start_bit, end_bit]
+			* \param[in] byte: The byte value.
+			* \param[in] start_bit: The start position of the bit range (inclusive). Range=[0,6] and must be less than end_bit.
+			* \param[in] end_bit: The end position of the bit range (inclusive). Range=[1,7] and must be greater than start_bit.
+			* \returns The value of the bit range as unsigned char. In case of an error 255 is returned and a message is written
+			* via std::cerr.
+			*/
+			uint8_t value_of_bits(uint8_t byte, uint8_t start_bit, uint8_t end_bit)
+			{
+				if (start_bit < 0 || start_bit > 7)
+				{
+					std::cerr << "SensorBase [bit_set] Error: The given start bit index (" << start_bit << ") is out of Bounds." << std::endl;
+					return 255;
+				}
+
+				if (end_bit < 0 || end_bit > 7)
+				{
+					std::cerr << "SensorBase [bit_set] Error: The given end bit index (" << end_bit << ") is out of Bounds." << std::endl;
+					return 255;
+				}
+
+				if (start_bit >= end_bit)
+				{
+					std::cerr << "SensorBase [bit_set] Error: Start index (" << start_bit << ") is greater or equal (" << end_bit << ")." << std::endl;
+					return 255;
+				}
+
+				uint8_t mask = 0;
+				for (uint8_t i = start_bit; i <= end_bit; ++i)
+				{
+					mask |= (uint8_t)(1 << i);
+				}
+
+				return (uint8_t)((mask & byte) >> start_bit);
+			}
+
+			//! Checks if the given pointer is null.
+			/*!
+			*  Checks if the given pointer is null.
+			* \param[in] pointer: The pointer to check.
+			* \returns 0 if the pointer is not null and -1 if the pointer is null.
+			*/
+			int8_t null_check(void* pointer)
+			{
+				if (pointer)
+				{
+					return OK;
+				}
+
+				return NULL_PTR;
+			}
+
+			//! Simply reads all content from the device at once.
+			/*!
+			*  Simply reads all content from the device at once. The function should only be used for
+			*  debug purposes.
+			* \param[out] all_data: A buffer to store the content.
+			* \returns 0 if reading all data was successful, a negative error value otherwise.
+			*/
+			virtual int8_t get_all_raw_data(uint8_t* all_data) = 0;
+
+			int m_file_handle;
+			uint8_t m_dev_id;
+			uint8_t m_id;
+			std::function<int8_t(const std::string, uint8_t, int&)> m_open_device_function;
+			std::function<int8_t(int&)> m_close_device_function;
+			std::function<int8_t(int, uint8_t, uint8_t*, uint16_t)> m_read_function;
+			std::function<int8_t(int, uint8_t, const uint8_t*, uint16_t)> m_write_function;
+		};
+	}
+}

--- a/PiDashboardBackend/src/manager/i2c_manager.cpp
+++ b/PiDashboardBackend/src/manager/i2c_manager.cpp
@@ -46,7 +46,12 @@ bool manager::i2c_manager::device_open(int handle)
 	return (handle > 0);
 }
 
-int8_t manager::i2c_manager::read_from_device(int handle, uint8_t address, std::unique_ptr<uint8_t[]>& data, uint16_t length)
+int8_t manager::i2c_manager::read_from_device_sp(int handle, uint8_t address, std::unique_ptr<uint8_t[]>& data, uint16_t length)
+{
+	return read_from_device(handle, address, data.get(), length);
+}
+
+int8_t manager::i2c_manager::read_from_device(int handle, uint8_t address, uint8_t* data, uint16_t length)
 {
 	if (!device_open(handle))
 	{
@@ -54,13 +59,13 @@ int8_t manager::i2c_manager::read_from_device(int handle, uint8_t address, std::
 		return -1;
 	}
 
-	data.get()[0] = address;
-	if (write(handle, data.get(), 1) != 1)
+	data[0] = address;
+	if (write(handle, data, 1) != 1)
 	{
 		std::cerr << "Could not got to read position 0x" << std::hex << address << std::dec << ". Error: " << strerror(errno) << std::endl;
 		return -1;
 	}
-	if (read(handle, data.get(), length) < 0)
+	if (read(handle, data, length) < 0)
 	{
 		std::cerr << "Could not read " << length << " bytes starting from 0x" << std::hex << address << std::dec << ". Error: " << strerror(errno) << std::endl;
 		return -1;
@@ -69,7 +74,12 @@ int8_t manager::i2c_manager::read_from_device(int handle, uint8_t address, std::
 	return 0;
 }
 
-int8_t manager::i2c_manager::write_to_device(int handle, uint8_t address, const std::unique_ptr<uint8_t[]>& data, uint16_t length)
+int8_t manager::i2c_manager::write_to_device_sp(int handle, uint8_t address, const std::unique_ptr<uint8_t[]>& data, uint16_t length)
+{
+	return write_to_device(handle, address, data.get(), length);	
+}
+
+int8_t manager::i2c_manager::write_to_device(int handle, uint8_t address, const uint8_t* data, uint16_t length)
 {
 	if (!device_open(handle))
 	{
@@ -81,7 +91,7 @@ int8_t manager::i2c_manager::write_to_device(int handle, uint8_t address, const 
 
 	buf = (int8_t*)malloc(length + 1);
 	buf[0] = address;
-	memcpy(buf + 1, data.get(), length);
+	memcpy(buf + 1, data, length);
 	if (write(handle, buf, length + 1) < length)
 	{
 		std::cerr << "Could not write data of length " << length << " to address 0x" << std::hex << address << std::dec << ". Error: " << strerror(errno) << std::endl;

--- a/PiDashboardBackend/src/manager/i2c_manager.h
+++ b/PiDashboardBackend/src/manager/i2c_manager.h
@@ -62,6 +62,18 @@ namespace manager
 		*/
 		static bool device_open(int handle);
 
+		//! Reads content from the given address to the smart pointer buffer.
+		/*!
+		*  First uses 'write' to set the file pointer to the desired address and afterwards
+		*  reads the desired amount of bytes into the given buffer.
+		* \param[in] handle: The handle that will be used to communicate over the i2c bus.
+		* \param[in] address: The file address to read from.
+		* \param[out] data: The buffer to which the file content will be read.
+		* \param[in] length: The number of bytes to read.
+		* \returns 0 if reading was successful, a negative error value otherwise.
+		*/
+		static int8_t read_from_device_sp(int handle, uint8_t address, std::unique_ptr<uint8_t[]>& data, uint16_t length);
+
 		//! Reads content from the given address to the buffer.
 		/*!
 		*  First uses 'write' to set the file pointer to the desired address and afterwards
@@ -72,7 +84,18 @@ namespace manager
 		* \param[in] length: The number of bytes to read.
 		* \returns 0 if reading was successful, a negative error value otherwise.
 		*/
-		static int8_t read_from_device(int handle, uint8_t address, std::unique_ptr<uint8_t[]>& data, uint16_t length);
+		static int8_t read_from_device(int handle, uint8_t address, uint8_t* data, uint16_t length);
+
+		//! Writes content to the given address from a smart pointer buffer.
+		/*!
+		*  Writes content to the given address from a buffer.
+		* \param[in] handle: The handle that will be used to communicate over the i2c bus.
+		* \param[in] address: The file address to write to.
+		* \param[in] data: The buffer containing the content to write.
+		* \param[in] length: The number of bytes to write.
+		* \returns 0 if writing was successful, a negative error value otherwise.
+		*/
+		static int8_t write_to_device_sp(int handle, uint8_t address, const std::unique_ptr<uint8_t[]>& data, uint16_t length);
 
 		//! Writes content to the given address from a buffer.
 		/*!
@@ -83,8 +106,8 @@ namespace manager
 		* \param[in] length: The number of bytes to write.
 		* \returns 0 if writing was successful, a negative error value otherwise.
 		*/
-		static int8_t write_to_device(int handle, uint8_t address, const std::unique_ptr<uint8_t[]>& data, uint16_t length);
+		static int8_t write_to_device(int handle, uint8_t address, const uint8_t* data, uint16_t length);
 
-		static constexpr const char* DEFAULT_PI_I2C_ADDRESS = "/dev/i2c-1";
+		static constexpr const char* DEFAULT_PI_I2C_PATH = "/dev/i2c-1";
 	};
 }


### PR DESCRIPTION
Add example code for ccs811 to main

Minor fixes
- Add some missing parameter documentation
- Replace unique pointers with shared pointers

Change warning values

Implement functions to communicate with ccs811

Add wiringPi and pthread to LibraryDependencies

Add helper functions for bit manipulation
- get number of set bits (bits that are 1)
- set multiple bits at once
- check if a single bit is set
- get the combined value of multiple bits

Add non-smart pointer variants of read and write functions

Minor changes in header files
- Some documentation
- Fix some wrong constants
- Change some datatypes in structs
- Change the order of operation modes in enum
- Add some more helper functions (especially for threading
- Add some private fields (especially for threading)
- Correctly implement abstract class sensor_base

The header of the implementation of the ccs811 sensor. It includes the definition and constants headers and derives from sensor_base.
It already provides all method declarations (together with documentation) that will be needed during the implementation.
Header file that contains structs and enums that will be used to implement the functionality of the ccs811 sensor. They help to structure the input and output date during communication with the sensor.
Header file that contains constants needed for implementation of the ccs811 co2 sensor. It contains register addresses, maxima, and minima as well as other constants
Add a sensor base class to outsource some common functionality each sensor needs into an abstract class.

Outsourced methods: init, close, null_check, read_all_raw_data
Outsourced fields: m_dev_id, m_id, m_device, read-, write-, open-, close-function pointers
Change naming from address to the more commonly used register in this context