### PR TITLE
Implementation of I2C ADS1115 converter

### DIFF
--- a/PiDashboardBackend/PiDashboardBackend.vcxproj
+++ b/PiDashboardBackend/PiDashboardBackend.vcxproj
@@ -35,6 +35,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="src\drivers\ads1115_converter.cpp" />
     <ClCompile Include="src\drivers\am312_motion.cpp" />
     <ClCompile Include="src\drivers\bme280_barometer.cpp" />
     <ClCompile Include="src\drivers\ccs811_co2.cpp" />
@@ -46,6 +47,9 @@
     <ClCompile Include="src\utils\iaq_calculator.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="src\drivers\ads1115_converter.h" />
+    <ClInclude Include="src\drivers\ads1115_converter_constants.h" />
+    <ClInclude Include="src\drivers\ads1115_converter_definitions.h" />
     <ClInclude Include="src\drivers\am312_motion.h" />
     <ClInclude Include="src\drivers\bme280_barometer.h" />
     <ClInclude Include="src\drivers\bme280_barometer_constants.h" />

--- a/PiDashboardBackend/PiDashboardBackend.vcxproj.filters
+++ b/PiDashboardBackend/PiDashboardBackend.vcxproj.filters
@@ -40,6 +40,7 @@
     <ClCompile Include="src\drivers\am312_motion.cpp">
       <Filter>drivers</Filter>
     </ClCompile>
+    <ClCompile Include="src\drivers\ads1115_converter.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\manager\db_manager.h">
@@ -85,6 +86,15 @@
       <Filter>utils</Filter>
     </ClInclude>
     <ClInclude Include="src\drivers\am312_motion.h">
+      <Filter>drivers</Filter>
+    </ClInclude>
+    <ClInclude Include="src\drivers\ads1115_converter.h">
+      <Filter>drivers</Filter>
+    </ClInclude>
+    <ClInclude Include="src\drivers\ads1115_converter_definitions.h">
+      <Filter>drivers</Filter>
+    </ClInclude>
+    <ClInclude Include="src\drivers\ads1115_converter_constants.h">
       <Filter>drivers</Filter>
     </ClInclude>
   </ItemGroup>

--- a/PiDashboardBackend/src/drivers/ads1115_converter.cpp
+++ b/PiDashboardBackend/src/drivers/ads1115_converter.cpp
@@ -1,0 +1,728 @@
+#include "ads1115_converter.h"
+
+int8_t driver::sensors::ads1115::converter::init(uint8_t device_reg, std::function<int8_t(int, uint8_t, uint8_t*, uint16_t)> read_function, std::function<int8_t(int, uint8_t, const uint8_t*, uint16_t)> write_function, std::function<int8_t(const std::string, uint8_t, int&)> open_device_function, std::function<int8_t(int&)> close_device_function)
+{
+	m_dev_id = device_reg;
+	m_read_function = read_function;
+	m_write_function = write_function;
+	m_open_device_function = open_device_function;
+	m_close_device_function = close_device_function;
+
+	if (m_open_device_function(manager::i2c_manager::DEFAULT_PI_I2C_PATH, m_dev_id, m_file_handle) != OK)
+	{
+		std::cerr << "ADS1115 [init] Error: Could not establish connection with device." << std::endl;
+		return DEVICE_NOT_FOUND;
+	}
+
+	return OK;
+}
+
+int8_t driver::sensors::ads1115::converter::close()
+{
+	return m_close_device_function(m_file_handle);
+}
+
+int8_t driver::sensors::ads1115::converter::soft_reset()
+{
+	uint8_t data[1] = { RESET_CMD };
+	if (write_operation(m_file_handle, RESET_REG, data, 1) != OK)
+	{
+		std::cerr << "ADS1115 [soft_reset] Error: Could not write soft reset command to device" << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	return OK;
+}
+
+int8_t driver::sensors::ads1115::converter::start_single_conversion()
+{
+	uint8_t current_settings[REG_READ_LEN] = { 0, 0 };
+	// Reading only the first byte is enough since all neccessary information is located there.
+	if (read_operation(m_file_handle, CONFIG_REG, current_settings) != OK)
+	{
+		std::cerr << "ADS1115 [start_single_conversion] Error: Could not read first byte of current device settings" << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	if ((uint8_t)is_bit_set(current_settings[0], 0) == (uint8_t)ads1115_operation_mode::CONTINUOUS)
+	{
+		return WARNING;
+	}
+
+	set_bit(current_settings[0], 7, true); // Set OS bit (7th) to true
+	if (write_operation(m_file_handle, CONFIG_REG, current_settings) != OK)
+	{
+		std::cerr << "ADS1115 [start_single_conversion] Error: Could not write first byte of current device settings" << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	return OK;
+}
+
+int8_t driver::sensors::ads1115::converter::is_converting(bool& is_converting)
+{
+	uint8_t current_settings[REG_READ_LEN] = { 0, 0 };
+	// Reading only the first byte is enough since all neccessary information is located there.
+	if (read_operation(m_file_handle, CONFIG_REG, current_settings) != OK)
+	{
+		std::cerr << "ADS1115 [is_converting] Error: Could not read first byte of current device settings" << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	is_bit_set(current_settings[0], 7) ? is_converting = false : is_converting = true;
+	return OK;
+}
+
+int8_t driver::sensors::ads1115::converter::get_multiplexer_setting(ads1115_multiplexer& current_multiplexer_setting)
+{
+	uint8_t current_settings[REG_READ_LEN] = { 0, 0 };
+	// Reading only the first byte is enough since all neccessary information is located there.
+	if (read_operation(m_file_handle, CONFIG_REG, current_settings) != OK)
+	{
+		std::cerr << "ADS1115 [get_multiplexer_setting] Error: Could not read first byte of current device settings" << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+	current_multiplexer_setting = parse_multiplexer_value(current_settings[0]);
+
+	return OK;
+}
+
+int8_t driver::sensors::ads1115::converter::get_gain_amplifier_setting(ads1115_gain_amplifier& current_gain_amplifier_setting)
+{
+	uint8_t current_settings[REG_READ_LEN] = { 0, 0 };
+	// Reading only the first byte is enough since all neccessary information is located there.
+	if (read_operation(m_file_handle, CONFIG_REG, current_settings) != OK)
+	{
+		std::cerr << "ADS1115 [get_gain_amplifier_setting] Error: Could not read first byte of current device settings" << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+	current_gain_amplifier_setting = parse_gain_amplifier_value(current_settings[0]);
+
+	return OK;
+}
+
+int8_t driver::sensors::ads1115::converter::get_operation_mode_setting(ads1115_operation_mode& current_operation_mode_setting)
+{
+	uint8_t current_settings[REG_READ_LEN] = { 0, 0 };
+	// Reading only the first byte is enough since all neccessary information is located there.
+	if (read_operation(m_file_handle, CONFIG_REG, current_settings) != OK)
+	{
+		std::cerr << "ADS1115 [get_operation_mode_setting] Error: Could not read first byte of current device settings" << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+	current_operation_mode_setting = parse_operation_mode_value(current_settings[0]);
+
+	return OK;
+}
+
+int8_t driver::sensors::ads1115::converter::get_data_rate_setting(ads1115_data_rate& current_data_rate_setting)
+{
+	uint8_t current_settings[REG_READ_LEN] = { 0, 0 };
+	if (read_operation(m_file_handle, CONFIG_REG, current_settings) != OK)
+	{
+		std::cerr << "ADS1115 [get_data_rate_setting] Error: Could not read current device settings" << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+	current_data_rate_setting = parse_data_rate_value(current_settings[1]);
+
+	return OK;
+}
+
+int8_t driver::sensors::ads1115::converter::get_comparator_mode_setting(ads1115_comparator_mode& current_comparator_mode_setting)
+{
+	uint8_t current_settings[REG_READ_LEN] = { 0, 0 };
+	if (read_operation(m_file_handle, CONFIG_REG, current_settings) != OK)
+	{
+		std::cerr << "ADS1115 [get_comparator_mode_setting] Error: Could not read current device settings" << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+	current_comparator_mode_setting = parse_comparator_mode_value(current_settings[1]);
+
+	return OK;
+}
+
+int8_t driver::sensors::ads1115::converter::get_comparator_polarity_setting(ads1115_alert_polarity& current_comparator_polarity_setting)
+{
+	uint8_t current_settings[REG_READ_LEN] = { 0, 0 };
+	if (read_operation(m_file_handle, CONFIG_REG, current_settings) != OK)
+	{
+		std::cerr << "ADS1115 [get_comparator_polarity_setting] Error: Could not read current device settings" << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+	current_comparator_polarity_setting = parse_comparator_polarity_value(current_settings[1]);
+
+	return OK;
+}
+
+int8_t driver::sensors::ads1115::converter::get_comparator_latching_setting(ads1115_alert_latching& current_comparator_latching_setting)
+{
+	uint8_t current_settings[REG_READ_LEN] = { 0, 0 };
+	if (read_operation(m_file_handle, CONFIG_REG, current_settings) != OK)
+	{
+		std::cerr << "ADS1115 [get_comparator_latching_setting] Error: Could not read current device settings" << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+	current_comparator_latching_setting = parse_comparator_latching_value(current_settings[1]);
+
+	return OK;
+}
+
+int8_t driver::sensors::ads1115::converter::get_comparator_queue_setting(ads1115_alert_queueing& current_comparator_queue_setting)
+{
+	uint8_t current_settings[REG_READ_LEN] = { 0, 0 };
+	if (read_operation(m_file_handle, CONFIG_REG, current_settings) != OK)
+	{
+		std::cerr << "ADS1115 [get_comparator_queue_setting] Error: Could not read current device settings" << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+	current_comparator_queue_setting = parse_comparator_queueing_value(current_settings[1]);
+
+	return OK;
+}
+
+int8_t driver::sensors::ads1115::converter::get_settings(ads1115_configuration& current_settings)
+{
+	uint8_t current_raw_settings[REG_READ_LEN] = { 0, 0 };
+	if (read_operation(m_file_handle, CONFIG_REG, current_raw_settings) != OK)
+	{
+		std::cerr << "ADS1115 [get_settings] Error: Could not read current device settings" << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	current_settings.multiplexer = parse_multiplexer_value(current_raw_settings[0]);
+	current_settings.gain_amplifier = parse_gain_amplifier_value(current_raw_settings[0]);
+	current_settings.operation_mode = parse_operation_mode_value(current_raw_settings[0]);
+	current_settings.data_rate = parse_data_rate_value(current_raw_settings[1]);
+	current_settings.comparator_mode = parse_comparator_mode_value(current_raw_settings[1]);
+	current_settings.alert_polarity = parse_comparator_polarity_value(current_raw_settings[1]);
+	current_settings.alert_latching = parse_comparator_latching_value(current_raw_settings[1]);
+	current_settings.alert_queueing = parse_comparator_queueing_value(current_raw_settings[1]);
+
+	return OK;
+}
+
+int8_t driver::sensors::ads1115::converter::set_multiplexer_setting(ads1115_multiplexer new_multiplexer_setting)
+{
+	uint8_t raw_settings[REG_READ_LEN] = { 0, 0 };
+	// Reading only the first byte is enough since all neccessary information is located there.
+	if (read_operation(m_file_handle, CONFIG_REG, raw_settings) != OK)
+	{
+		std::cerr << "ADS1115 [set_multiplexer_setting] Error: Could not read current device settings" << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	set_bits(raw_settings[0], (uint8_t)new_multiplexer_setting, MULTIPLEXER_MASK);
+	if (write_operation(m_file_handle, CONFIG_REG, raw_settings) != OK)
+	{
+		std::cerr << "ADS1115 [set_multiplexer_setting] Error: Could not write new device settings" << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	return OK;
+}
+
+int8_t driver::sensors::ads1115::converter::set_gain_amplifier_setting(ads1115_gain_amplifier new_gain_amplifier_setting)
+{
+	uint8_t raw_settings[REG_READ_LEN] = { 0, 0 };
+	// Reading only the first byte is enough since all neccessary information is located there.
+	if (read_operation(m_file_handle, CONFIG_REG, raw_settings) != OK)
+	{
+		std::cerr << "ADS1115 [set_gain_amplifier_setting] Error: Could not read current device settings" << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	set_bits(raw_settings[0], (uint8_t)new_gain_amplifier_setting, GAIN_AMPLIFIER_MASK);
+	if (write_operation(m_file_handle, CONFIG_REG, raw_settings) != OK)
+	{
+		std::cerr << "ADS1115 [set_gain_amplifier_setting] Error: Could not write new device settings" << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	return OK;
+}
+
+int8_t driver::sensors::ads1115::converter::set_operation_mode_setting(ads1115_operation_mode new_operation_mode_setting)
+{
+	uint8_t raw_settings[REG_READ_LEN] = { 0, 0 };
+	// Reading only the first byte is enough since all neccessary information is located there.
+	if (read_operation(m_file_handle, CONFIG_REG, raw_settings) != OK)
+	{
+		std::cerr << "ADS1115 [set_operation_mode_setting] Error: Could not read current device settings" << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	set_bits(raw_settings[0], (uint8_t)new_operation_mode_setting, OPERATION_MODE_MASK);
+	if (write_operation(m_file_handle, CONFIG_REG, raw_settings) != OK)
+	{
+		std::cerr << "ADS1115 [set_operation_mode_setting] Error: Could not write new device settings" << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	return OK;
+}
+
+int8_t driver::sensors::ads1115::converter::set_data_rate_setting(ads1115_data_rate new_data_rate_setting)
+{
+	uint8_t raw_settings[REG_READ_LEN] = { 0, 0 };
+	if (read_operation(m_file_handle, CONFIG_REG, raw_settings) != OK)
+	{
+		std::cerr << "ADS1115 [set_data_rate_setting] Error: Could not read current device settings" << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	set_bits(raw_settings[1], (uint8_t)new_data_rate_setting, DATA_RATE_MASK);
+	if (write_operation(m_file_handle, CONFIG_REG, raw_settings) != OK)
+	{
+		std::cerr << "ADS1115 [set_data_rate_setting] Error: Could not write new device settings" << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	return OK;
+}
+
+int8_t driver::sensors::ads1115::converter::set_comparator_mode_setting(ads1115_comparator_mode new_comparator_mode_setting)
+{
+	uint8_t raw_settings[REG_READ_LEN] = { 0, 0 };
+	if (read_operation(m_file_handle, CONFIG_REG, raw_settings) != OK)
+	{
+		std::cerr << "ADS1115 [set_comparator_mode_setting] Error: Could not read current device settings" << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	set_bits(raw_settings[1], (uint8_t)new_comparator_mode_setting, COMPARATOR_MODE_MASK);
+	if (write_operation(m_file_handle, CONFIG_REG, raw_settings) != OK)
+	{
+		std::cerr << "ADS1115 [set_comparator_mode_setting] Error: Could not write new device settings" << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	return OK;
+}
+
+int8_t driver::sensors::ads1115::converter::set_comparator_polarity_setting(ads1115_alert_polarity new_comparator_polarity_setting)
+{
+	uint8_t raw_settings[REG_READ_LEN] = { 0, 0 };
+	if (read_operation(m_file_handle, CONFIG_REG, raw_settings) != OK)
+	{
+		std::cerr << "ADS1115 [set_comparator_polarity_setting] Error: Could not read current device settings" << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	set_bits(raw_settings[1], (uint8_t)new_comparator_polarity_setting, COMPARATOR_POLARITY_MASK);
+	if (write_operation(m_file_handle, CONFIG_REG, raw_settings) != OK)
+	{
+		std::cerr << "ADS1115 [set_comparator_polarity_setting] Error: Could not write new device settings" << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	return OK;
+}
+
+int8_t driver::sensors::ads1115::converter::set_comparator_latching_setting(ads1115_alert_latching new_comparator_latching_setting)
+{
+	uint8_t raw_settings[REG_READ_LEN] = { 0, 0 };
+	if (read_operation(m_file_handle, CONFIG_REG, raw_settings) != OK)
+	{
+		std::cerr << "ADS1115 [set_comparator_latching_setting] Error: Could not read current device settings" << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	set_bits(raw_settings[1], (uint8_t)new_comparator_latching_setting, COMPARATOR_LATCHING_MASK);
+	if (write_operation(m_file_handle, CONFIG_REG, raw_settings) != OK)
+	{
+		std::cerr << "ADS1115 [set_comparator_latching_setting] Error: Could not write new device settings" << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	return OK;
+}
+
+int8_t driver::sensors::ads1115::converter::set_comparator_queue_setting(ads1115_alert_queueing new_comparator_queue_setting)
+{
+	uint8_t raw_settings[REG_READ_LEN] = { 0, 0 };
+	if (read_operation(m_file_handle, CONFIG_REG, raw_settings) != OK)
+	{
+		std::cerr << "ADS1115 [set_comparator_queue_setting] Error: Could not read current device settings" << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	set_bits(raw_settings[1], (uint8_t)new_comparator_queue_setting, COMPARATOR_QUEUEING_MASK);
+	if (write_operation(m_file_handle, CONFIG_REG, raw_settings) != OK)
+	{
+		std::cerr << "ADS1115 [set_comparator_queue_setting] Error: Could not write new device settings" << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	return OK;
+}
+
+int8_t driver::sensors::ads1115::converter::set_settings(ads1115_configuration new_settings)
+{
+	uint8_t raw_settings[REG_READ_LEN] = { 0, 0 };
+	set_bits(raw_settings[0], (uint8_t)new_settings.multiplexer, MULTIPLEXER_MASK);
+	set_bits(raw_settings[0], (uint8_t)new_settings.gain_amplifier, GAIN_AMPLIFIER_MASK);
+	set_bits(raw_settings[0], (uint8_t)new_settings.operation_mode, OPERATION_MODE_MASK);
+	set_bits(raw_settings[1], (uint8_t)new_settings.data_rate, DATA_RATE_MASK);
+	set_bits(raw_settings[1], (uint8_t)new_settings.comparator_mode, COMPARATOR_MODE_MASK);
+	set_bits(raw_settings[1], (uint8_t)new_settings.alert_polarity, COMPARATOR_POLARITY_MASK);
+	set_bits(raw_settings[1], (uint8_t)new_settings.alert_latching, COMPARATOR_LATCHING_MASK);
+	set_bits(raw_settings[1], (uint8_t)new_settings.alert_queueing, COMPARATOR_QUEUEING_MASK);
+
+	if (write_operation(m_file_handle, CONFIG_REG, raw_settings) != OK)
+	{
+		std::cerr << "ADS1115 [set_settings] Error: Could not write new device settings" << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	return OK;
+}
+
+int8_t driver::sensors::ads1115::converter::restore_default_settings()
+{
+	uint8_t default_settings[REG_READ_LEN] = { DEFAULT_SETTINGS_BYTE_1, DEFAULT_SETTINGS_BYTE_2 };
+	if (write_operation(m_file_handle, CONFIG_REG, default_settings) != OK)
+	{
+		std::cerr << "ADS1115 [restore_default_settings] Error: Could not restore default device settings" << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	return OK;
+}
+
+int8_t driver::sensors::ads1115::converter::get_converted_data(double& converted_data)
+{
+	uint8_t raw_converted[REG_READ_LEN] = { 0, 0 };
+	if (read_operation(m_file_handle, CONVERSION_REG, raw_converted) != OK)
+	{
+		std::cerr << "ADS1115 [get_converted_data] Error: Could not read converted data." << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	converted_data = combine_bytes(raw_converted[0], raw_converted[1]);
+	converted_data /= 10000;
+	return OK;
+}
+
+int8_t driver::sensors::ads1115::converter::get_upper_threshold(uint16_t& upper_threshold)
+{
+	uint8_t raw_threshold[REG_READ_LEN] = { 0, 0 };
+	if (read_operation(m_file_handle, HIGH_THRESHOLD_REG, raw_threshold) != OK)
+	{
+		std::cerr << "ADS1115 [get_upper_threshold] Error: Could not read upper threshold." << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	upper_threshold = combine_bytes(raw_threshold[0], raw_threshold[1]);
+	return OK;
+}
+
+int8_t driver::sensors::ads1115::converter::get_lower_threshold(uint16_t& lower_threshold)
+{
+	uint8_t raw_threshold[REG_READ_LEN] = { 0, 0 };
+	if (read_operation(m_file_handle, LOW_THRESHOLD_REG, raw_threshold) != OK)
+	{
+		std::cerr << "ADS1115 [get_lower_threshold] Error: Could not read lower threshold." << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	lower_threshold = combine_bytes(raw_threshold[0], raw_threshold[1]);
+	return OK;
+}
+
+int8_t driver::sensors::ads1115::converter::get_thresholds(uint16_t& lower_threshold, uint16_t& upper_threshold)
+{
+	if (get_upper_threshold(upper_threshold) != OK)
+	{
+		std::cerr << "ADS1115 [get_thresholds] Error: Could not read upper threshold." << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+	if (get_lower_threshold(lower_threshold) != OK)
+	{
+		std::cerr << "ADS1115 [get_thresholds] Error: Could not read lower threshold." << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	return OK;
+}
+
+int8_t driver::sensors::ads1115::converter::set_upper_threshold(uint16_t upper_threshold)
+{
+	uint8_t splitted_threshold[REG_READ_LEN] = { 0, 0 };
+	split_bytes(upper_threshold, splitted_threshold[0], splitted_threshold[1]);
+	if (write_operation(m_file_handle, HIGH_THRESHOLD_REG, splitted_threshold) != OK)
+	{
+		std::cerr << "ADS1115 [set_upper_threshold] Error: Could not write upper threshold." << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	return OK;
+}
+
+int8_t driver::sensors::ads1115::converter::set_lower_threshold(uint16_t lower_threshold)
+{
+	uint8_t splitted_threshold[REG_READ_LEN] = { 0, 0 };
+	split_bytes(lower_threshold, splitted_threshold[0], splitted_threshold[1]);
+	if (write_operation(m_file_handle, LOW_THRESHOLD_REG, splitted_threshold) != OK)
+	{
+		std::cerr << "ADS1115 [set_lower_threshold] Error: Could not write lower threshold." << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	return OK;
+}
+
+int8_t driver::sensors::ads1115::converter::set_thresholds(uint16_t lower_threshold, uint16_t upper_threshold)
+{
+	if (set_upper_threshold(upper_threshold) != OK)
+	{
+		std::cerr << "ADS1115 [set_thresholds] Error: Could not read upper threshold." << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+	if (set_lower_threshold(lower_threshold) != OK)
+	{
+		std::cerr << "ADS1115 [set_thresholds] Error: Could not read lower threshold." << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	return OK;
+}
+
+int8_t driver::sensors::ads1115::converter::restore_default_upper_thresholds()
+{
+	uint8_t default_threshold[REG_READ_LEN] = { DEFAULT_HIGH_THRES_BYTE_1, DEFAULT_HIGH_THRES_BYTE_2 };
+	if (write_operation(m_file_handle, HIGH_THRESHOLD_REG, default_threshold) != OK)
+	{
+		std::cerr << "ADS1115 [restore_default_upper_thresholds] Error: Could not restore default high threshold" << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	return OK;
+}
+
+int8_t driver::sensors::ads1115::converter::restore_default_lower_thresholds()
+{
+	uint8_t default_threshold[REG_READ_LEN] = { DEFAULT_LOW_THRES_BYTE_1, DEFAULT_LOW_THRES_BYTE_2 };
+	if (write_operation(m_file_handle, LOW_THRESHOLD_REG, default_threshold) != OK)
+	{
+		std::cerr << "ADS1115 [restore_default_lower_thresholds] Error: Could not restore default low threshold" << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	return OK;
+}
+
+int8_t driver::sensors::ads1115::converter::restore_default_thresholds()
+{
+	if (restore_default_upper_thresholds() != OK)
+	{
+		std::cerr << "ADS1115 [restore_default_thresholds] Error: Could not restore default upper threshold." << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+	if (restore_default_lower_thresholds() != OK)
+	{
+		std::cerr << "ADS1115 [restore_default_thresholds] Error: Could not restore default lower threshold." << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	return OK;
+}
+
+int8_t driver::sensors::ads1115::converter::get_all_raw_data(uint8_t* all_data)
+{
+	// No need to implement this method for this device
+	return OK;
+}
+
+driver::sensors::ads1115::ads1115_multiplexer driver::sensors::ads1115::converter::parse_multiplexer_value(uint8_t raw_data)
+{
+	switch (value_of_bits(raw_data, MULTIPLEXER_BIT_1, MULTIPLEXER_BIT_3))
+	{
+	case 0:
+		return ads1115_multiplexer::POSITIVE_0_AND_NEGATIVE_1;
+	case 1:
+		return ads1115_multiplexer::POSITIVE_0_AND_NEGATIVE_3;
+	case 2:
+		return ads1115_multiplexer::POSITIVE_1_AND_NEGATIVE_3;
+	case 3:
+		return ads1115_multiplexer::POSITIVE_2_AND_NEGATIVE_3;
+	case 4:
+		return ads1115_multiplexer::POSITIVE_0_AND_NEGATIVE_GND;
+	case 5:
+		return ads1115_multiplexer::POSITIVE_1_AND_NEGATIVE_GND;
+	case 6:
+		return ads1115_multiplexer::POSITIVE_2_AND_NEGATIVE_GND;
+	case 7:
+		return ads1115_multiplexer::POSITIVE_3_AND_NEGATIVE_GND;
+	default:
+		return ads1115_multiplexer::POSITIVE_0_AND_NEGATIVE_1;
+	}
+}
+
+driver::sensors::ads1115::ads1115_gain_amplifier driver::sensors::ads1115::converter::parse_gain_amplifier_value(uint8_t raw_data)
+{
+	switch (value_of_bits(raw_data, GAIN_AMPLIFIER_BIT_1, GAIN_AMPLIFIER_BIT_3))
+	{
+	case 0:
+		return ads1115_gain_amplifier::GAIN_6144_mV;
+	case 1:
+		return ads1115_gain_amplifier::GAIN_4096_mV;
+	case 2:
+		return ads1115_gain_amplifier::GAIN_2048_mV;
+	case 3:
+		return ads1115_gain_amplifier::GAIN_1024_mV;
+	case 4:
+		return ads1115_gain_amplifier::GAIN_512_mV;
+	case 5:
+	case 6:
+	case 7:
+		return ads1115_gain_amplifier::GAIN_256_mV;
+	default:
+		return ads1115_gain_amplifier::GAIN_2048_mV;
+	}
+}
+
+driver::sensors::ads1115::ads1115_operation_mode driver::sensors::ads1115::converter::parse_operation_mode_value(uint8_t raw_data)
+{
+	if (is_bit_set(raw_data, OPERATION_MODE_BIT))
+	{
+		return ads1115_operation_mode::SINGLE_SHOT;
+	}
+	else
+	{
+		return ads1115_operation_mode::CONTINUOUS;
+	}
+}
+
+driver::sensors::ads1115::ads1115_data_rate driver::sensors::ads1115::converter::parse_data_rate_value(uint8_t raw_data)
+{
+	switch (value_of_bits(raw_data, GAIN_AMPLIFIER_BIT_1, GAIN_AMPLIFIER_BIT_3))
+	{
+	case 0:
+		return ads1115_data_rate::RATE_8_SPS;
+	case 1:
+		return ads1115_data_rate::RATE_16_SPS;
+	case 2:
+		return ads1115_data_rate::RATE_32_SPS;
+	case 3:
+		return ads1115_data_rate::RATE_64_SPS;
+	case 4:
+		return ads1115_data_rate::RATE_128_SPS;
+	case 5:
+		return ads1115_data_rate::RATE_250_SPS;
+	case 6:
+		return ads1115_data_rate::RATE_475_SPS;
+	case 7:
+		return ads1115_data_rate::RATE_860_SPS;
+	default:
+		return ads1115_data_rate::RATE_128_SPS;
+	}
+}
+
+driver::sensors::ads1115::ads1115_comparator_mode driver::sensors::ads1115::converter::parse_comparator_mode_value(uint8_t raw_data)
+{
+	if (is_bit_set(raw_data, COMPARATOR_MODE_BIT))
+	{
+		return ads1115_comparator_mode::WINDOW;
+	}
+	else
+	{
+		return ads1115_comparator_mode::HYSTERESIS;
+	}
+}
+
+driver::sensors::ads1115::ads1115_alert_polarity driver::sensors::ads1115::converter::parse_comparator_polarity_value(uint8_t raw_data)
+{
+	if (is_bit_set(raw_data, COMPARATOR_POL_BIT))
+	{
+		return ads1115_alert_polarity::ACTIVE_HIGH;
+	}
+	else
+	{
+		return ads1115_alert_polarity::ACTIVE_LOW;
+	}
+}
+
+driver::sensors::ads1115::ads1115_alert_latching driver::sensors::ads1115::converter::parse_comparator_latching_value(uint8_t raw_data)
+{
+	if (is_bit_set(raw_data, COMPARATOR_LAT_BIT))
+	{
+		return ads1115_alert_latching::ACTIVE;
+	}
+	else
+	{
+		return ads1115_alert_latching::DISABLED;
+	}
+}
+
+driver::sensors::ads1115::ads1115_alert_queueing driver::sensors::ads1115::converter::parse_comparator_queueing_value(uint8_t raw_data)
+{
+	switch (value_of_bits(raw_data, COMPARATOR_QUEUE_BIT_1, COMPARATOR_QUEUE_BIT_2))
+	{
+	case 0:
+		return ads1115_alert_queueing::ASSERT_1_CONVERSION;
+	case 1:
+		return ads1115_alert_queueing::ASSERT_2_CONVERSIONS;
+	case 2:
+		return ads1115_alert_queueing::ASSERT_4_CONVERSIONS;
+	case 3:
+		return ads1115_alert_queueing::DISABLED;
+	default:
+		return ads1115_alert_queueing::DISABLED;
+	}
+}
+
+int8_t driver::sensors::ads1115::converter::write_operation(int handle, uint8_t address, const uint8_t* buffer, uint16_t length)
+{
+	if (handle == 0)
+	{
+		std::cerr << "Device #" << handle << " is not open." << std::endl;
+		return -1;
+	}
+
+	if (m_write_function != nullptr)
+	{
+		return m_write_function(handle, address, buffer, length);
+	}
+
+	uint8_t write_buffer[3] = { 0, 0, 0 };
+	write_buffer[0] = address;
+	write_buffer[1] = buffer[0];
+	write_buffer[2] = buffer[1];
+	if (write(handle, write_buffer, length + 1) != length + 1)
+	{
+		std::cerr << "Could not switch pointer to register address 0x" << std::hex << address << std::dec << " and write data 0x" 
+			<< std::hex << buffer[0] << std::dec << "', 0x" << std::hex << buffer[0] << std::dec << ". Error: " << strerror(errno) << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	return OK;
+}
+
+int8_t driver::sensors::ads1115::converter::read_operation(int handle, uint8_t address, uint8_t* buffer, uint16_t length)
+{
+	if (handle == 0)
+	{
+		std::cerr << "Device #" << handle << " is not open." << std::endl;
+		return -1;
+	}
+
+	if (m_read_function != nullptr)
+	{
+		return m_write_function(handle, address, buffer, length);
+	}
+
+
+	if (write(handle, &address, 1) != 1)
+	{
+		std::cerr << "Could not switch to register with address 0x" << std::hex << address << std::dec << ". Error: " << strerror(errno) << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+
+	if (read(handle, buffer, length) != length)
+	{
+		std::cerr << "Could not read data of length " << length << " from address 0x" << std::hex << address << std::dec << ". Error: " << strerror(errno) << std::endl;
+		return COMMUNICATION_FAIL;
+	}
+	
+	return OK;
+}

--- a/PiDashboardBackend/src/drivers/ads1115_converter.h
+++ b/PiDashboardBackend/src/drivers/ads1115_converter.h
@@ -1,0 +1,414 @@
+#pragma once
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <wiringPi.h>
+#include <thread>
+#include <vector>
+
+#include "sensor_base.h"
+#include "ads1115_converter_constants.h"
+#include "ads1115_converter_definitions.h"
+#include "../manager/i2c_manager.h"
+
+namespace driver
+{
+	namespace sensors
+	{
+		namespace ads1115
+		{
+			//! Class that communicates with the ADS1115 analog-digital-converter via I2C.
+			/*!
+			* This class implements various functions to configure the converter and receive the converted data.
+			*/
+			class converter : sensor_base
+			{
+			public:
+				//! Default constructor.
+				/*!
+				* Default constructor.
+				*/
+				converter() {}
+
+				//! Default destructor.
+				/*!
+				* Default destructor.
+				*/
+				~converter() {  }
+
+				//! Opens a device connection and performs basic setup.
+				/*!
+				* Tries to open the device at the given i2c address in O_RDWR and I2C_SLAVE mode.
+				* \param[in] device_reg: The address of the device to open. The default value is 48 (address pin is connected to nothing or ground).
+				* \param[in] read_function: Function pointer to the function that does i2c read operations.
+				* \param[in] write_function: Function pointer to the function that does i2c write operations.
+				* \param[in] open_device_function: Function pointer to the function that opens an i2c connection.
+				* \param[in] close_device_function: Function pointer to the function that closes an i2c connection.
+				* \returns 0 if initializing the device was successful, a negative error value otherwise.
+				*/
+				virtual int8_t init(uint8_t device_reg = CONVERTER_ADDR_IS_GND_I2C_REG,
+					std::function<int8_t(int, uint8_t, uint8_t*, uint16_t)> read_function = nullptr,
+					std::function<int8_t(int, uint8_t, const uint8_t*, uint16_t)> write_function = nullptr,
+					std::function<int8_t(const std::string, uint8_t, int&)> open_device_function = manager::i2c_manager::open_device,
+					std::function<int8_t(int&)> close_device_function = manager::i2c_manager::close_device) override;
+				
+				//! Closes a device connection and performs some cleanup.
+				/*!
+				*  Closes a device connection and performs some cleanup.
+				* \returns 0 if closing the device was successful, a negative error value otherwise.
+				*/
+				virtual int8_t close() override;
+
+				//! Performs a soft reset on the device.
+				/*!
+				* Performs a soft reset on the device.
+				* \returns 0 if resetting the device was successful, a negative error value otherwise.
+				*/
+				virtual int8_t soft_reset() override;
+
+				//! Triggers the device to start a single conversion.
+				/*!
+				* Triggers the device to start a single conversion.
+				* \returns 0 if starting a conversion was successful, a negative error value otherwise.
+				*/
+				int8_t start_single_conversion();
+
+				//! Checks whether the device is currently converting an analog value.
+				/*!
+				* Checks whether the device is currently converting an analog value.
+				* \param[out] is_converting: Whether the device is currently converting or not.
+				* \returns 0 if getting the conversion state was successful, a negative error value otherwise.
+				*/
+				int8_t is_converting(bool& is_converting);
+
+				//! Returns the current multiplexer setting.
+				/*!
+				* Returns the current multiplexer setting.
+				* \param[out] current_multiplexer_setting: The current multiplexer setting.
+				* \returns 0 if getting the multiplexer setting was successful, a negative error value otherwise.
+				*/
+				int8_t get_multiplexer_setting(ads1115_multiplexer& current_multiplexer_setting);
+
+				//! Returns the current gain amplifier setting.
+				/*!
+				* Returns the current gain amplifier setting.
+				* \param[out] current_gain_amplifier_setting: The current gain amplifier setting.
+				* \returns 0 if getting the gain amplifier setting was successful, a negative error value otherwise.
+				*/
+				int8_t get_gain_amplifier_setting(ads1115_gain_amplifier& current_gain_amplifier_setting);
+
+				//! Returns the current operation mode setting.
+				/*!
+				* Returns the current operation mode setting.
+				* \param[out] current_operation_mode_setting: The current operation mode setting.
+				* \returns 0 if getting the operation mode setting was successful, a negative error value otherwise.
+				*/
+				int8_t get_operation_mode_setting(ads1115_operation_mode& current_operation_mode_setting);
+
+				//! Returns the current data rate setting.
+				/*!
+				* Returns the current data rate setting.
+				* \param[out] current_data_rate_setting: The current data rate setting.
+				* \returns 0 if getting the data rate setting was successful, a negative error value otherwise.
+				*/
+				int8_t get_data_rate_setting(ads1115_data_rate& current_data_rate_setting);
+
+				//! Returns the current comparator mode setting.
+				/*!
+				* Returns the current comparator mode setting.
+				* \param[out] current_comparator_mode_setting: The current comparator mode setting.
+				* \returns 0 if getting the comparator mode setting was successful, a negative error value otherwise.
+				*/
+				int8_t get_comparator_mode_setting(ads1115_comparator_mode& current_comparator_mode_setting);
+
+				//! Returns the current comparator polarity setting.
+				/*!
+				* Returns the current comparator polarity setting.
+				* \param[out] current_comparator_polarity_setting: The current comparator polarity setting.
+				* \returns 0 if getting the comparator polarity setting was successful, a negative error value otherwise.
+				*/
+				int8_t get_comparator_polarity_setting(ads1115_alert_polarity& current_comparator_polarity_setting);
+
+				//! Returns the current comparator latching setting.
+				/*!
+				* Returns the current comparator latching setting.
+				* \param[out] current_comparator_latching_setting: The current comparator latching setting.
+				* \returns 0 if getting the comparator latching setting was successful, a negative error value otherwise.
+				*/
+				int8_t get_comparator_latching_setting(ads1115_alert_latching& current_comparator_latching_setting);
+
+				//! Returns the current comparator queue setting.
+				/*!
+				* Returns the current comparator queue setting.
+				* \param[out] current_comparator_queue_setting: The current comparator queue setting.
+				* \returns 0 if getting the comparator queue setting was successful, a negative error value otherwise.
+				*/
+				int8_t get_comparator_queue_setting(ads1115_alert_queueing& current_comparator_queue_setting);
+
+				//! Returns the current device configuration.
+				/*!
+				* Returns the current device configuration.
+				* \param[out] current_settings: The current device configuration.
+				* \returns 0 if getting the device configuration was successful, a negative error value otherwise.
+				*/
+				int8_t get_settings(ads1115_configuration& current_settings);
+
+				//! Sets a new multiplexer setting.
+				/*!
+				* Sets a new multiplexer setting.
+				* \param[in] new_multiplexer_setting: The new multiplexer setting.
+				* \returns 0 if setting the multiplexer setting was successful, a negative error value otherwise.
+				*/
+				int8_t set_multiplexer_setting(ads1115_multiplexer new_multiplexer_setting);
+
+				//! Sets a new gain amplifier setting.
+				/*!
+				* Sets a new gain amplifier setting.
+				* \param[in] new_gain_amplifier_setting: The new gain amplifier setting.
+				* \returns 0 if setting the gain amplifier setting was successful, a negative error value otherwise.
+				*/
+				int8_t set_gain_amplifier_setting(ads1115_gain_amplifier new_gain_amplifier_setting);
+
+				//! Sets a new operation mode setting.
+				/*!
+				* Sets a new operation mode setting.
+				* \param[in] new_operation_mode_setting: The new operation mode setting.
+				* \returns 0 if setting the operation mode setting was successful, a negative error value otherwise.
+				*/
+				int8_t set_operation_mode_setting(ads1115_operation_mode new_operation_mode_setting);
+
+				//! Sets a new data rate setting.
+				/*!
+				* Sets a new data rate setting.
+				* \param[in] new_data_rate_setting: The new data rate setting.
+				* \returns 0 if setting the data rate setting was successful, a negative error value otherwise.
+				*/
+				int8_t set_data_rate_setting(ads1115_data_rate new_data_rate_setting);
+
+				//! Sets a new comparator mode setting.
+				/*!
+				* Sets a new comparator mode setting.
+				* \param[in] new_comparator_mode_setting: The new comparator mode setting.
+				* \returns 0 if setting the comparator mode setting was successful, a negative error value otherwise.
+				*/
+				int8_t set_comparator_mode_setting(ads1115_comparator_mode new_comparator_mode_setting);
+
+				//! Sets a new comparator polarity setting.
+				/*!
+				* Sets a new comparator polarity setting.
+				* \param[in] new_comparator_polarity_setting: The new comparator polarity setting.
+				* \returns 0 if setting the comparator polarity setting was successful, a negative error value otherwise.
+				*/
+				int8_t set_comparator_polarity_setting(ads1115_alert_polarity new_comparator_polarity_setting);
+
+				//! Sets a new comparator latching setting.
+				/*!
+				* Sets a new comparator latching setting.
+				* \param[in] new_comparator_latching_setting: The new comparator latching setting.
+				* \returns 0 if setting the comparator latching setting was successful, a negative error value otherwise.
+				*/
+				int8_t set_comparator_latching_setting(ads1115_alert_latching new_comparator_latching_setting);
+
+				//! Sets a new comparator queue setting.
+				/*!
+				* Sets a new comparator queue setting.
+				* \param[in] new_comparator_queue_setting: The new comparator queue setting.
+				* \returns 0 if setting the comparator queue setting was successful, a negative error value otherwise.
+				*/
+				int8_t set_comparator_queue_setting(ads1115_alert_queueing new_comparator_queue_setting);
+
+				//! Sets all settings at once.
+				/*!
+				* Sets all settings at once.
+				* \param[in] new_settings: The new settings.
+				* \returns 0 if setting the settings was successful, a negative error value otherwise.
+				*/
+				int8_t set_settings(struct ads1115_configuration new_settings);
+
+				//! Sets all settings back to their default values.
+				/*!
+				* Sets all settings back to their default values.
+				* \returns 0 if setting the settings was successful, a negative error value otherwise.
+				*/
+				int8_t restore_default_settings();
+
+				//! Returns the last converted data.
+				/*!
+				* Returns the last converted data.
+				* \param[out] converted_data: The converted data.
+				* \returns 0 if getting the converted data was successful, a negative error value otherwise.
+				*/
+				int8_t get_converted_data(double& converted_data);
+
+				//! Returns the upper (high) threshold.
+				/*!
+				* Returns the upper (high) threshold.
+				* \param[out] upper_threshold: The upper (high) threshold.
+				* \returns 0 if getting the upper threshold was successful, a negative error value otherwise.
+				*/
+				int8_t get_upper_threshold(uint16_t& upper_threshold);
+
+				//! Returns the lower (low) threshold.
+				/*!
+				* Returns the lower (low) threshold.
+				* \param[out] lower_threshold: The lower (low) threshold.
+				* \returns 0 if getting the lower threshold was successful, a negative error value otherwise.
+				*/
+				int8_t get_lower_threshold(uint16_t& lower_threshold);
+
+				//! Returns both thresholds.
+				/*!
+				* Returns both (upper & lower) thresholds.
+				* \param[out] lower_threshold: The lower (low) threshold.
+				* \param[out] upper_threshold: The upper (high) threshold.
+				* \returns 0 if getting the thresholds was successful, a negative error value otherwise.
+				*/
+				int8_t get_thresholds(uint16_t& lower_threshold, uint16_t& upper_threshold);
+
+				//! Sets the upper (high) threshold.
+				/*!
+				* Sets the upper (high) threshold.
+				* \param[in] upper_threshold: The upper (high) threshold.
+				* \returns 0 if setting the upper threshold was successful, a negative error value otherwise.
+				*/
+				int8_t set_upper_threshold(uint16_t upper_threshold);
+
+				//! Sets the lower (low) threshold.
+				/*!
+				* Sets the lower (low) threshold.
+				* \param[in] lower_threshold: The lower (low) threshold.
+				* \returns 0 if setting the lower threshold was successful, a negative error value otherwise.
+				*/
+				int8_t set_lower_threshold(uint16_t lower_threshold);
+
+				//! Sets both thresholds.
+				/*!
+				* Sets both (upper & lower) thresholds.
+				* \param[in] lower_threshold: The lower (low) threshold.
+				* \param[in] upper_threshold: The upper (high) threshold.
+				* \returns 0 if setting the thresholds was successful, a negative error value otherwise.
+				*/
+				int8_t set_thresholds(uint16_t lower_threshold, uint16_t upper_threshold);
+
+				//! Sets the upper threshold back to its default value.
+				/*!
+				* Sets the upper threshold back to its default value.
+				* \returns 0 if setting the thresholds was successful, a negative error value otherwise.
+				*/
+				int8_t restore_default_upper_thresholds();
+
+				//! Sets the lower threshold back to its default value.
+				/*!
+				* Sets the lower threshold back to its default value.
+				* \returns 0 if setting the thresholds was successful, a negative error value otherwise.
+				*/
+				int8_t restore_default_lower_thresholds();
+
+				//! Sets both thresholds back to their default values.
+				/*!
+				* Sets both thresholds back to their default values.
+				* \returns 0 if setting the thresholds was successful, a negative error value otherwise.
+				*/
+				int8_t restore_default_thresholds();
+
+			protected:
+				//! Simply reads all content from the device at once.
+				/*!
+				*  Simply reads all content from the device at once. The function should only be used for
+				*  debug purposes.
+				* \param[out] all_data: A buffer to store the content.
+				* \returns 0 if reading all data was successful, a negative error value otherwise.
+				*/
+				virtual int8_t get_all_raw_data(uint8_t* all_data) override;
+
+			private:
+				//! Extracts the multiplexer bits from the given byte and parses them into the resulting enum.
+				/*!
+				*  Extracts the multiplexer bits from the given byte and parses them into the resulting enum.
+				* \param[in] raw_data: A setting byte that was read from the device.
+				* \returns The parsed multiplexer value as ads1115_multiplexer enum.
+				*/
+				ads1115_multiplexer parse_multiplexer_value(uint8_t raw_data);
+
+				//! Extracts the gain amplifier bits from the given byte and parses them into the resulting enum.
+				/*!
+				*  Extracts the gain amplifier bits from the given byte and parses them into the resulting enum.
+				* \param[in] raw_data: A setting byte that was read from the device.
+				* \returns The parsed gain amplifier value as ads1115_gain_amplifier enum.
+				*/
+				ads1115_gain_amplifier parse_gain_amplifier_value(uint8_t raw_data);
+
+				//! Extracts the operation mode bit from the given byte and parses it into the resulting enum.
+				/*!
+				*  Extracts the operation mode bit from the given byte and parses it into the resulting enum.
+				* \param[in] raw_data: A setting byte that was read from the device.
+				* \returns The parsed operation mode value as ads1115_operation_mode enum.
+				*/
+				ads1115_operation_mode parse_operation_mode_value(uint8_t raw_data);
+
+				//! Extracts the data rate bits from the given byte and parses them into the resulting enum.
+				/*!
+				*  Extracts the data rate bits from the given byte and parses them into the resulting enum.
+				* \param[in] raw_data: A setting byte that was read from the device.
+				* \returns The parsed data rate value as ads1115_data_rate enum.
+				*/
+				ads1115_data_rate parse_data_rate_value(uint8_t raw_data);
+
+				//! Extracts the comparator mode bit from the given byte and parses it into the resulting enum.
+				/*!
+				*  Extracts the comparator mode bit from the given byte and parses it into the resulting enum.
+				* \param[in] raw_data: A setting byte that was read from the device.
+				* \returns The parsed comparator mode value as ads1115_comparator_mode enum.
+				*/
+				ads1115_comparator_mode parse_comparator_mode_value(uint8_t raw_data);
+
+				//! Extracts the comparator polarity bit from the given byte and parses it into the resulting enum.
+				/*!
+				*  Extracts the comparator polarity bit from the given byte and parses it into the resulting enum.
+				* \param[in] raw_data: A setting byte that was read from the device.
+				* \returns The parsed comparator polarity value as ads1115_alert_polarity enum.
+				*/
+				ads1115_alert_polarity parse_comparator_polarity_value(uint8_t raw_data);
+
+				//! Extracts the comparator latching bit from the given byte and parses it into the resulting enum.
+				/*!
+				*  Extracts the comparator latching bit from the given byte and parses it into the resulting enum.
+				* \param[in] raw_data: A setting byte that was read from the device.
+				* \returns The parsed comparator latching value as ads1115_alert_latching enum.
+				*/
+				ads1115_alert_latching parse_comparator_latching_value(uint8_t raw_data);
+
+				//! Extracts the comparator queueing bits from the given byte and parses them into the resulting enum.
+				/*!
+				*  Extracts the comparator queueing bits from the given byte and parses them into the resulting enum.
+				* \param[in] raw_data: A setting byte that was read from the device.
+				* \returns The parsed comparator queueing value as ads1115_alert_queueing enum.
+				*/
+				ads1115_alert_queueing parse_comparator_queueing_value(uint8_t raw_data);
+
+				//! Fallback i2c write function that is used if m_write_function is nullptr.
+				/*!
+				*  Fallback i2c write function that is used if m_write_function is nullptr.
+				* \param[in] handle: The handle that will be used to communicate over the i2c bus.
+				* \param[in] address: The file address to write to.
+				* \param[in] data: The buffer containing the content to write.
+				* \param[in] length: The number of bytes to write. Default is 2.
+				* \returns 0 if writing was successful, a negative error value otherwise.
+				*/
+				int8_t write_operation(int handle, uint8_t address, const uint8_t* buffer, uint16_t length = 2);
+
+				//! Fallback i2c read function that is used if m_read_function is nullptr.
+				/*!
+				*  Fallback i2c write function that is used if m_read_function is nullptr.
+				* \param[in] handle: The handle that will be used to communicate over the i2c bus.
+				* \param[in] address: The file address to write to.
+				* \param[in] data: The buffer containing the content to write.
+				* \param[in] length: The number of bytes to write.
+				* \returns 0 if reading was successful, a negative error value otherwise.
+				*/
+				int8_t read_operation(int handle, uint8_t address, uint8_t* buffer, uint16_t length = 2);
+			};
+		}
+	}
+}

--- a/PiDashboardBackend/src/drivers/ads1115_converter_constants.h
+++ b/PiDashboardBackend/src/drivers/ads1115_converter_constants.h
@@ -1,0 +1,63 @@
+#pragma once
+
+namespace driver
+{
+	namespace sensors
+	{
+		namespace ads1115
+		{
+			// I2C device addresses
+			static constexpr const uint8_t CONVERTER_ADDR_IS_GND_I2C_REG = 0X48;
+			static constexpr const uint8_t CONVERTER_ADDR_IS_VDD_I2C_REG = 0X49;
+			static constexpr const uint8_t CONVERTER_ADDR_IS_SDA_I2C_REG = 0X4A;
+			static constexpr const uint8_t CONVERTER_ADDR_IS_SCL_I2C_REG = 0X4B;
+
+			// Reset
+			static constexpr const uint8_t RESET_REG = 0X00;
+			static constexpr const uint8_t RESET_CMD = 0X06;
+
+			// Register addresses
+			static constexpr const uint8_t CONVERSION_REG = 0X00;
+			static constexpr const uint8_t CONFIG_REG = 0X01;
+			static constexpr const uint8_t LOW_THRESHOLD_REG = 0X02;
+			static constexpr const uint8_t HIGH_THRESHOLD_REG = 0X03;
+
+			// Read length
+			static constexpr const uint8_t REG_READ_LEN = 2;
+
+			// Bit indices
+			static constexpr const uint8_t STATUS_BIT = 7;
+			static constexpr const uint8_t MULTIPLEXER_BIT_3 = 6;
+			static constexpr const uint8_t MULTIPLEXER_BIT_1 = 4;
+			static constexpr const uint8_t GAIN_AMPLIFIER_BIT_3 = 3;
+			static constexpr const uint8_t GAIN_AMPLIFIER_BIT_1 = 1;
+			static constexpr const uint8_t OPERATION_MODE_BIT = 0;
+
+			static constexpr const uint8_t DATA_RATE_BIT_3 = 7;
+			static constexpr const uint8_t DATA_RATE_BIT_1 = 5;
+			static constexpr const uint8_t COMPARATOR_MODE_BIT = 4;
+			static constexpr const uint8_t COMPARATOR_POL_BIT = 3;
+			static constexpr const uint8_t COMPARATOR_LAT_BIT = 2;
+			static constexpr const uint8_t COMPARATOR_QUEUE_BIT_2 = 1;
+			static constexpr const uint8_t COMPARATOR_QUEUE_BIT_1 = 0;
+
+			// Bit masks
+			static constexpr const uint8_t MULTIPLEXER_MASK = 0x70;
+			static constexpr const uint8_t GAIN_AMPLIFIER_MASK = 0x0E;
+			static constexpr const uint8_t OPERATION_MODE_MASK = 0x01;
+			static constexpr const uint8_t DATA_RATE_MASK = 0xE0;
+			static constexpr const uint8_t COMPARATOR_MODE_MASK = 0x10;
+			static constexpr const uint8_t COMPARATOR_POLARITY_MASK = 0x08;
+			static constexpr const uint8_t COMPARATOR_LATCHING_MASK = 0x04;
+			static constexpr const uint8_t COMPARATOR_QUEUEING_MASK = 0x03;
+
+			// Default values
+			static constexpr const uint8_t DEFAULT_SETTINGS_BYTE_1 = 0x85;
+			static constexpr const uint8_t DEFAULT_SETTINGS_BYTE_2 = 0x83;
+			static constexpr const uint8_t DEFAULT_LOW_THRES_BYTE_1 = 0x80;
+			static constexpr const uint8_t DEFAULT_LOW_THRES_BYTE_2 = 0x00;
+			static constexpr const uint8_t DEFAULT_HIGH_THRES_BYTE_1 = 0x7F;
+			static constexpr const uint8_t DEFAULT_HIGH_THRES_BYTE_2 = 0xFF;
+		}
+	}
+}

--- a/PiDashboardBackend/src/drivers/ads1115_converter_definitions.h
+++ b/PiDashboardBackend/src/drivers/ads1115_converter_definitions.h
@@ -1,0 +1,89 @@
+#pragma once
+
+namespace driver
+{
+	namespace sensors
+	{
+		namespace ads1115
+		{
+			enum class ads1115_operation_mode : int8_t
+			{
+				CONTINUOUS = 0,
+				SINGLE_SHOT = 1
+			};
+
+			enum class ads1115_multiplexer : int8_t
+			{
+				POSITIVE_0_AND_NEGATIVE_1 = 0,
+				POSITIVE_0_AND_NEGATIVE_3 = 1,
+				POSITIVE_1_AND_NEGATIVE_3 = 2,
+				POSITIVE_2_AND_NEGATIVE_3 = 3,
+				POSITIVE_0_AND_NEGATIVE_GND = 4,
+				POSITIVE_1_AND_NEGATIVE_GND = 5,
+				POSITIVE_2_AND_NEGATIVE_GND = 6,
+				POSITIVE_3_AND_NEGATIVE_GND = 7
+			};
+
+			enum class ads1115_gain_amplifier : int8_t
+			{
+				GAIN_6144_mV = 0,
+				GAIN_4096_mV = 1,
+				GAIN_2048_mV = 2,
+				GAIN_1024_mV = 3,
+				GAIN_512_mV = 4,
+				GAIN_256_mV = 5
+
+			};
+
+			enum class ads1115_data_rate : int8_t
+			{
+				RATE_8_SPS = 0,
+				RATE_16_SPS = 1,
+				RATE_32_SPS = 2,
+				RATE_64_SPS = 3,
+				RATE_128_SPS = 4,
+				RATE_250_SPS = 5,
+				RATE_475_SPS = 6,
+				RATE_860_SPS = 7
+			};
+
+			enum class ads1115_comparator_mode : int8_t
+			{
+				HYSTERESIS = 0,
+				WINDOW = 1
+			};
+
+			enum class ads1115_alert_polarity : int8_t
+			{
+				ACTIVE_LOW = 0,
+				ACTIVE_HIGH = 1
+			};
+
+			enum class ads1115_alert_latching : int8_t
+			{
+				DISABLED = 0,
+				ACTIVE = 1
+			};
+
+			enum class ads1115_alert_queueing : int8_t
+			{
+				ASSERT_1_CONVERSION = 0,
+				ASSERT_2_CONVERSIONS = 1,
+				ASSERT_4_CONVERSIONS = 2,
+				DISABLED = 3
+			};
+
+			struct ads1115_configuration
+			{
+				ads1115_operation_mode operation_mode = ads1115_operation_mode::SINGLE_SHOT;
+				ads1115_multiplexer multiplexer = ads1115_multiplexer::POSITIVE_0_AND_NEGATIVE_1;
+				ads1115_gain_amplifier gain_amplifier = ads1115_gain_amplifier::GAIN_2048_mV;
+				ads1115_data_rate data_rate = ads1115_data_rate::RATE_128_SPS;
+				ads1115_comparator_mode comparator_mode = ads1115_comparator_mode::HYSTERESIS;
+				ads1115_alert_polarity alert_polarity = ads1115_alert_polarity::ACTIVE_LOW;
+				ads1115_alert_latching alert_latching = ads1115_alert_latching::DISABLED;
+				ads1115_alert_queueing alert_queueing = ads1115_alert_queueing::DISABLED;
+			};
+		}
+	}
+}

--- a/PiDashboardBackend/src/drivers/ccs811_co2.cpp
+++ b/PiDashboardBackend/src/drivers/ccs811_co2.cpp
@@ -446,7 +446,7 @@ int8_t driver::sensors::ccs811::co2::get_eCO2_data(uint16_t& eCO2)
 			return COMMUNICATION_FAIL;
 		}
 
-		eCO2 = (uint16_t)((raw_results[0] << 8) | raw_results[1]);
+		eCO2 = combine_bytes(raw_results[0], raw_results[1]);
 		return OK;
 	}
 
@@ -467,7 +467,7 @@ int8_t driver::sensors::ccs811::co2::get_TVOC_data(uint16_t& TVOC)
 			return COMMUNICATION_FAIL;
 		}
 
-		TVOC = (uint16_t)((raw_results[2] << 8) | raw_results[3]);
+		TVOC = combine_bytes(raw_results[2], raw_results[3]);
 		return OK;
 	}
 
@@ -506,12 +506,12 @@ int8_t driver::sensors::ccs811::co2::get_all_result_data(std::shared_ptr<struct 
 			return COMMUNICATION_FAIL;
 		}
 
-		result->eco2_value = (uint16_t)((raw_results[0] << 8) | raw_results[1]);
-		result->tvoc_value = (uint16_t)((raw_results[2] << 8) | raw_results[3]);
+		result->eco2_value = combine_bytes(raw_results[0], raw_results[1]);
+		result->tvoc_value = combine_bytes(raw_results[2], raw_results[3]);
 		result->status = raw_results[4];
 		result->error_id = raw_results[5];
 		result->raw_data.current = value_of_bits(raw_results[6], 2, 7);
-		result->raw_data.voltage = (uint16_t)(value_of_bits(raw_results[6], 0, 1) << 8 | (raw_results[7]));
+		result->raw_data.voltage = combine_bytes(value_of_bits(raw_results[6], 0, 1), raw_results[7]);
 
 		return OK;
 	}
@@ -573,8 +573,8 @@ int8_t driver::sensors::ccs811::co2::get_NTC_data(std::shared_ptr<struct ccs811_
 			return COMMUNICATION_FAIL;
 		}
 
-		ntc->v_over_resistor = (uint16_t)((ntc_results[0] << 8) | ntc_results[1]);
-		ntc->v_over_ntc = (uint16_t)((ntc_results[2] << 8) | ntc_results[3]);
+		ntc->v_over_resistor = combine_bytes(ntc_results[0], ntc_results[1]);
+		ntc->v_over_ntc = combine_bytes(ntc_results[2], ntc_results[3]);
 
 		return OK;
 	}

--- a/PiDashboardBackend/src/drivers/ccs811_co2.h
+++ b/PiDashboardBackend/src/drivers/ccs811_co2.h
@@ -36,11 +36,11 @@ namespace driver
 				* \param[in] close_device_function: Function pointer to the function that closes an i2c connection.
 				* \returns 0 if initializing the device was successful, a negative error value otherwise.
 				*/
-				int8_t init(uint8_t device_reg = SENSOR_PRIMARY_I2C_REG,
+				virtual int8_t init(uint8_t device_reg = SENSOR_PRIMARY_I2C_REG,
 					std::function<int8_t(int, uint8_t, uint8_t*, uint16_t)> read_function = manager::i2c_manager::read_from_device,
 					std::function<int8_t(int, uint8_t, const uint8_t*, uint16_t)> write_function = manager::i2c_manager::write_to_device,
 					std::function<int8_t(const std::string, uint8_t, int&)> open_device_function = manager::i2c_manager::open_device,
-					std::function<int8_t(int&)> close_device_function = manager::i2c_manager::close_device);
+					std::function<int8_t(int&)> close_device_function = manager::i2c_manager::close_device) override;
 
 			public:
 				//! Default constructor.
@@ -85,7 +85,7 @@ namespace driver
 				*  Closes a device connection and performs some cleanup.
 				* \returns 0 if closing the device was successful, a negative error value otherwise.
 				*/
-				int8_t close();
+				virtual int8_t close() override;
 
 				//! Activates or deactivates the power safe mode.
 				/*!

--- a/PiDashboardBackend/src/drivers/sensor_base.h
+++ b/PiDashboardBackend/src/drivers/sensor_base.h
@@ -9,7 +9,7 @@ namespace driver
 {
 	namespace sensors
 	{
-		static constexpr const int8_t WARNING = 0;
+		static constexpr const int8_t WARNING = 1;
 		static constexpr const int8_t OK = 0;
 		static constexpr const int8_t NULL_PTR = -1;
 		static constexpr const int8_t DEVICE_NOT_FOUND = -2;
@@ -115,10 +115,30 @@ namespace driver
 					std::cerr << "SensorBase [set_bits] Error: The given mask has less bits set than the value. This would result in unintentional bit changes." << std::endl;
 					return false;
 				}
+
+				int8_t index = (int8_t)(index_of_highest_active_bit(mask) - index_of_highest_active_bit(value));
+				value = (uint8_t)(value << index);
 				
 				// Turn off currently set bits at mask position and afterwards set the desired bits.
-				byte = (uint8_t)((byte & ~mask) | value); 
+				byte = (uint8_t)((byte & ~mask) | value);
 				return true;
+			}
+
+			//! Returns the index of the highest active bit.
+			/*!
+			*  Returns the index of the highest active bit.
+			* \param[in] byte: The byte value.
+			* \returns The index of the highest active bit.
+			*/
+			int8_t index_of_highest_active_bit(uint8_t byte)
+			{
+				int8_t index = 0;
+				while ((uint8_t)(byte >> index) != 0)
+				{
+					index++;
+				}
+				
+				return (int8_t)(index - 1);
 			}
 
 			//! Counts the bits in a byte that are set to 1.
@@ -172,6 +192,31 @@ namespace driver
 				}
 
 				return (uint8_t)((mask & byte) >> start_bit);
+			}
+
+			//! Combines two 8 bit values to one 16 bit value.
+			/*!
+			*  Combines two 8 bit values to one 16 bit value.
+			* \param[in] high_byte: The first byte value. Represents the high part of the resulting 16 bit value.
+			* \param[in] low_byte: The second byte value. Represents the low part of the resulting 16 bit value.
+			* \returns The value of the combined bytes as 16 bit value.
+			*/
+			uint16_t combine_bytes(uint8_t high_byte, uint8_t low_byte)
+			{
+				return (uint16_t)((high_byte << 8) | low_byte);
+			}
+
+			//! Combines two 8 bit values to one 16 bit value.
+			/*!
+			*  Combines two 8 bit values to one 16 bit value.
+			* \param[in] value: The 16 bit value to split.
+			* \param[out] high_byte: The first byte value. Represents the high part of the resulting 16 bit value.
+			* \param[out] low_byte: The second byte value. Represents the low part of the resulting 16 bit value.
+			*/
+			void split_bytes(uint16_t value, uint8_t& high_byte, uint8_t& low_byte)
+			{
+				high_byte = (uint8_t)(value & 0xFF);
+				low_byte = (uint8_t)(value >> 8);
 			}
 
 			//! Checks if the given pointer is null.

--- a/PiDashboardBackend/src/main.cpp
+++ b/PiDashboardBackend/src/main.cpp
@@ -2,6 +2,7 @@
 #include "drivers/bme280_barometer.h"
 #include "drivers/ccs811_co2.h"
 #include "drivers/am312_motion.h"
+#include "drivers/ads1115_converter.h"
 #include "dto/sensor_dto.h"
 #include "utils/time_converter.h"
 
@@ -48,6 +49,13 @@ void print_ccs811_menu()
 	std::cout << "------------------------\n";
 }
 
+void print_ads1115_menu()
+{
+	std::cout << "1: Data Rate\n";
+	std::cout << "2: Gain Amplifier\n";
+	std::cout << "3: Run\n";
+	std::cout << "------------------------\n";
+}
 
 void print(std::shared_ptr<dto::sensor_dto> entry)
 {
@@ -271,6 +279,89 @@ void am312_testing()
 	}
 }
 
+void ads1115_testing()
+{
+	auto ads1115 = std::make_shared<driver::sensors::ads1115::converter>();
+	ads1115->init();
+
+	driver::sensors::ads1115::ads1115_configuration config;
+	ads1115->restore_default_settings();
+	ads1115->get_settings(config);
+	std::cout << "Multiplexer: " << (int)config.multiplexer << std::endl;
+	std::cout << "Gain Amplifier: " << (int)config.gain_amplifier << std::endl;
+	std::cout << "Operation Mode: " << (int)config.operation_mode << std::endl;
+	std::cout << "Data Rate: " << (int)config.data_rate << std::endl;
+	std::cout << "Comparator Mode: " << (int)config.comparator_mode << std::endl;
+	std::cout << "Comparator Polarity: " << (int)config.alert_polarity << std::endl;
+	std::cout << "Comparator Latching: " << (int)config.alert_latching << std::endl;
+	std::cout << "Comparator Queueing: " << (int)config.alert_queueing << std::endl;
+
+	ads1115->set_multiplexer_setting(driver::sensors::ads1115::ads1115_multiplexer::POSITIVE_0_AND_NEGATIVE_GND);
+	ads1115->set_operation_mode_setting(driver::sensors::ads1115::ads1115_operation_mode::CONTINUOUS);
+
+	int choose;
+	while (true)
+	{
+		print_ads1115_menu();
+		std::cin >> choose;
+
+		switch (choose)
+		{
+		case 1:
+		{
+			int dr;
+			std::cout << "8 SPS: 0" << std::endl;
+			std::cout << "16 SPS: 1" << std::endl;
+			std::cout << "32 SPS: 2" << std::endl;
+			std::cout << "64 SPS: 3" << std::endl;
+			std::cout << "128 SPS: 4" << std::endl;
+			std::cout << "250 SPS: 5" << std::endl;
+			std::cout << "475 SPS: 6" << std::endl;
+			std::cout << "860 SPS: 7" << std::endl;
+			std::cin >> dr;
+
+			ads1115->get_settings(config);
+			std::cout << "Current DR: " << (int)config.data_rate << std::endl;
+
+			ads1115->set_data_rate_setting((driver::sensors::ads1115::ads1115_data_rate)dr);
+			ads1115->get_settings(config);
+			std::cout << "New DR: " << (int)config.data_rate << std::endl;
+		}
+		break;
+		case 2:
+		{
+			int gain;
+			std::cout << "6.144 V: 0" << std::endl;
+			std::cout << "4.096 V: 1" << std::endl;
+			std::cout << "2.048 V: 2" << std::endl;
+			std::cout << "1.024 V: 3" << std::endl;
+			std::cout << "0.512 V: 4" << std::endl;
+			std::cout << "0.256 V: 5" << std::endl;
+			std::cin >> gain;
+
+			ads1115->get_settings(config);
+			std::cout << "Current Gain: " << (int)config.gain_amplifier << std::endl;
+
+			ads1115->set_gain_amplifier_setting((driver::sensors::ads1115::ads1115_gain_amplifier)gain);
+			ads1115->get_settings(config);
+			std::cout << "New Gain: " << (int)config.gain_amplifier << std::endl;
+		}
+		break;
+		case 3:
+		{
+			double raw;
+			while (true)
+			{
+				ads1115->get_converted_data(raw);
+				std::cout << raw << " V" << std::endl;
+				delay(1000);
+			}
+		}
+		break;
+		}
+	}
+}
+
 int main()
 {
 	printf("hello from PiSensorBackend!\n");
@@ -278,7 +369,8 @@ int main()
 	//database_testing();
 	//bme280_testing();
 	//ccs811_testing();
-	am312_testing();
+	//am312_testing();
+	ads1115_testing();
 
 	return 0;
 }


### PR DESCRIPTION
Update test code in main
Add implementation of ads1115 converter
Add a function to combine two bytes to a 16 bit value and one function to split a 16 bit value into two bytes.
Use this functions in ccs811 co2 sensor implementation
Add bit masks and rename some existing constants
Add function definitions and documentation for ads1115
Add virtual and override to functions that are inherited from the base class and need to be overwritten
Fix namespaces
Define settings enums and settings struct for ads1115
Define register and mask constants for ads1115